### PR TITLE
Fix warnings about format macros inside of panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Frame Language Transpiler v0.4.2
+# Frame Language Transpiler v0.4.3
 
 Hi! So very glad you are interested in Frame. Frame system design markdown language for software architects and engineers. It is an easy to learn textual language for defining system specifications that can generate both UML documentation as well as code in 7 langauges. 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Frame Language Transpiler v0.4.1
+# Frame Language Transpiler v0.4.2
 
 Hi! So very glad you are interested in Frame. Frame system design markdown language for software architects and engineers. It is an easy to learn textual language for defining system specifications that can generate both UML documentation as well as code in 7 langauges. 
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ This project contains the code for building the Frame Language Transpiler - the 
 
 ## Resources
 
-The Frame project is just getting started but there are some resources and communities to help.
+The Frame project is just getting started but there are some resources and communities to help. You can now download [VSCode](https://marketplace.visualstudio.com/items?itemName=frame-lang-org.frame-machine-maker) and [Atom](https://atom.io/packages/frame-machine-maker) extensions to work with Frame in these popular free development applications.
 
-An [online version of the Framepiler](https://framepiler.frame-lang.org) is available and provides examples and links to other resources. You can learn more about the Frame language at [frame-lang.org](https://frame-lang.org) as well as find general resources about programming with automata at Reddit ![re](https://www.google.com/s2/favicons?domain_url=https://reddit.com) on the [r/statemachines](https://www.reddit.com/r/statemachines/) subreddit.
+An [online version of the Framepiler](https://framepiler.frame-lang.org) is also available and provides examples and links to other resources. You can learn more about the Frame language at [frame-lang.org](https://frame-lang.org) as well as find general resources about programming with automata at Reddit ![re](https://www.google.com/s2/favicons?domain_url=https://reddit.com) on the [r/statemachines](https://www.reddit.com/r/statemachines/) subreddit.
 
 Communities exist at [Gitter](https://gitter.im/frame-language/community) and [Discord](https://discord.com/invite/CfbU4QCbSD).
 
 ### Frame Examples
 The [Framepiler](https://framepiler.frame-lang.org/example/aHR0cHM6Ly9naXN0LmdpdGh1Yi5jb20vZnJhbWUtbGFuZy8wZGFmMDMzOGU0YTkyYjc1NWViMTQ2NGM3YzVjMTM3Zg==) itself has a number of examples baked into it but I also have started a [Gitter Frame Examples](https://gitter.im/frame-language/frame-examples) channel for contributions. The Framepiler supports links to Gists so please create and share!
+
+The [Frame Solution Depot](https://github.com/frame-lang/frame_solution_depot) is a Github repo and growing body of examples and test specifications. This is useful in conjunction with the [VSCode](https://marketplace.visualstudio.com/items?itemName=frame-lang-org.frame-machine-maker) and [Atom](https://atom.io/packages/frame-machine-maker) extensions.
 
 ## Bugs and Problems
 
@@ -25,8 +27,6 @@ For now please report issues to the [Gitter Bug Channel](https://gitter.im/frame
 ## Getting Started
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
-
-
 
 
 ### Installing

--- a/examples/HelloWorld.frm
+++ b/examples/HelloWorld.frm
@@ -1,5 +1,32 @@
-#ConditionalSyntax
+--- try on https://frame-lang.org
+
+#World
+
+    -interface-
+
+    start @(|>>|)
+    stop @(|<<|)
 
     -machine-
+
+    $Begin
+        |>>|
+            -> "start" $Working ^
+
+    $Working => $Default
+        |>|
+            print("Hello World") ^
+
+    $End
+        |>|
+            print("End of the World") ^
+
+    $Default
+        |<<|
+            -> "stop" $End ^
+
+    -actions-
+
+    print[msg:string]:void
 
 ##

--- a/framec/src/frame_c/scanner.rs
+++ b/framec/src/frame_c/scanner.rs
@@ -181,7 +181,7 @@ impl Scanner {
 
             }
             '$' => {
-                enum StackType {Push,Pop};
+                enum StackType {Push,Pop}
 
                 if self.match_char('$') {
                     let st;

--- a/framec/src/frame_c/symbol_table.rs
+++ b/framec/src/frame_c/symbol_table.rs
@@ -928,7 +928,7 @@ impl ScopeSymbol for SystemSymbol {
             let e = d.get_symbol_table_for_symbol(symbol_name);
             return Rc::clone(&e);
         } else {
-            panic!(format!("Fatal error - could not find symbol {} in system scope.", symbol_name));
+            panic!("Fatal error - could not find symbol {} in system scope.", symbol_name);
         }
     }
 }
@@ -957,7 +957,7 @@ impl ScopeSymbol for InterfaceBlockSymbol {
             let e = d.get_symbol_table_for_symbol(symbol_name);
             return Rc::clone(&e);
         } else {
-            panic!(format!("Fatal error - could not find symbol {} in interface block scope.", symbol_name));
+            panic!("Fatal error - could not find symbol {} in interface block scope.", symbol_name);
 
         }
     }
@@ -995,7 +995,7 @@ impl ScopeSymbol for InterfaceMethodSymbol {
             let e = d.get_symbol_table_for_symbol(symbol_name);
             return Rc::clone(&e);
         } else {
-            panic!(format!("Fatal error - could not find symbol {} in interface method scope.", symbol_name));
+            panic!("Fatal error - could not find symbol {} in interface method scope.", symbol_name);
         }
     }
 }
@@ -1097,7 +1097,7 @@ impl ScopeSymbol for MachineBlockScopeSymbol {
             let e = d.get_symbol_table_for_symbol(symbol_name);
             return Rc::clone(&e);
         } else {
-            panic!(format!("Fatal error - could not find symbol {} in machine block scope.", symbol_name));
+            panic!("Fatal error - could not find symbol {} in machine block scope.", symbol_name);
         }
     }
 }
@@ -1245,7 +1245,7 @@ impl StateSymbol {
             let e = d.get_symbol_table_for_symbol(symbol_name);
             return Rc::clone(&e);
         } else {
-            panic!(format!("Fatal error - could not find symbol {} in state scope.", symbol_name));
+            panic!("Fatal error - could not find symbol {} in state scope.", symbol_name);
         }
     }
 }
@@ -1349,7 +1349,7 @@ impl ScopeSymbol for StateParamsScopeSymbol {
             let e = d.get_symbol_table_for_symbol(symbol_name);
             return Rc::clone(&e);
         } else {
-            panic!(format!("Fatal error - could not find symbol {} in state parameters scope.", symbol_name));
+            panic!("Fatal error - could not find symbol {} in state parameters scope.", symbol_name);
         }
     }
 }
@@ -1406,7 +1406,7 @@ impl ScopeSymbol for StateLocalScopeSymbol {
             let e = d.get_symbol_table_for_symbol(symbol_name);
             return Rc::clone(&e);
         } else {
-            panic!(format!("Fatal error - could not find symbol {} in state local scope.", symbol_name));
+            panic!("Fatal error - could not find symbol {} in state local scope.", symbol_name);
         }
     }
 }
@@ -1456,7 +1456,7 @@ impl ScopeSymbol for EventHandlerScopeSymbol {
             let e = d.get_symbol_table_for_symbol(symbol_name);
             return Rc::clone(&e);
         } else {
-            panic!(format!("Fatal error - could not find symbol {} in event handler scope.", symbol_name));
+            panic!("Fatal error - could not find symbol {} in event handler scope.", symbol_name);
         }
     }
 }
@@ -1532,7 +1532,7 @@ impl ScopeSymbol for EventHandlerParamsScopeSymbol {
             let e = d.get_symbol_table_for_symbol(symbol_name);
             return Rc::clone(&e);
         } else {
-            panic!(format!("Fatal error - could not find symbol {} in event handler params scope.", symbol_name));
+            panic!("Fatal error - could not find symbol {} in event handler params scope.", symbol_name);
         }
     }
 }
@@ -1590,7 +1590,7 @@ impl ScopeSymbol for EventHandlerLocalScopeSymbol {
             let e = d.get_symbol_table_for_symbol(symbol_name);
             return Rc::clone(&e);
         } else {
-            panic!(format!("Fatal error - could not find symbol {} in event handler local scope.", symbol_name));
+            panic!("Fatal error - could not find symbol {} in event handler local scope.", symbol_name);
         }
     }
 }
@@ -1641,7 +1641,7 @@ impl ScopeSymbol for ActionsBlockScopeSymbol {
             let e = d.get_symbol_table_for_symbol(symbol_name);
             return Rc::clone(&e);
         } else {
-            panic!(format!("Fatal error - could not find symbol {} in actions block scope.", symbol_name));
+            panic!("Fatal error - could not find symbol {} in actions block scope.", symbol_name);
         }
     }
 }
@@ -1698,7 +1698,7 @@ impl ScopeSymbol for DomainBlockScopeSymbol {
             let e = d.get_symbol_table_for_symbol(symbol_name);
             return Rc::clone(&e);
         } else {
-            panic!(format!("Fatal error - could not find symbol {} in domain block scope.", symbol_name));
+            panic!("Fatal error - could not find symbol {} in domain block scope.", symbol_name);
         }
     }
 }


### PR DESCRIPTION
This fixes several warnings about unnecessary `format!` macros inside of `panic!` macros, which will be disallowed in Rust 2021. The fixed versions work in current Rust and going forward.

Also removes one redundant semicolon warning.