### PR TITLE
Introspection feature: refactor get_state_enum() method

### DIFF
--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -585,10 +585,10 @@ impl RustVisitor {
                 for state in &machine_block_node.states {
                     self.add_code(&format!("{} self.state as *const {} == {}::{} as *const {} {{ {}{}::{} }}"
                                             ,if_else_if
-                                            ,self.config.frame_event_type_name
+                                            ,self.config.frame_state_type_name
                                             ,self.system_name
                                             ,self.format_state_name(state.borrow().name.as_str())
-                                            ,self.config.frame_event_type_name
+                                            ,self.config.frame_state_type_name
                                             ,self.system_name
                                             ,self.config.state_enum_suffix
                                             ,state.borrow().name


### PR DESCRIPTION
This refactors the generated `get_state_enum()` method into two methods:

 * `get_state_enum(state)` returns an Option containing the enum value corresponding to the argument state.

 * `get_current_state_enum()` retains the behavior of the original method. It returns the enum value corresponding to the current state of the machine, or panics if the machine is in an invalid state.

The rationale for this refactoring is that it allows determining the enum value of a state, regardless of whether its the current state of the machine. This will be useful, for example, when monitoring transitions to determine the value of the next state before actually transitioning.

Also fixes a minor bug where the wrong raw pointer type was being used in the comparisons.