### PR TITLE
Add derived traits for state enum.

### DIFF
--- a/framec/src/frame_c/default_config.yaml
+++ b/framec/src/frame_c/default_config.yaml
@@ -31,10 +31,9 @@ codegen:
       state_var_name_prefix:
       state_var_name_suffix: _state
       state_enum_suffix: State
+      state_enum_traits: Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord
       transition_method_name: transition
       change_state_method_name: change_state
       state_stack_var_name: state_stack
       state_stack_push_method_name: state_stack_push
       state_stack_pop_method_name: state_stack_pop
-
-            


### PR DESCRIPTION
This adds derived traits to the state enum type for the Rust backend.

It adds one new configuration option and two new attributes:

 * The config option `state_enum_traits` is a string defining the traits to derive by default for the state enum in every state machine. In the default config, this is set to `Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord`. The rationale for the large set of traits in the default config is to derive as many standard traits as possible by default, [following the advice here](https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits), but of course this is easy to change.

 * The attribute `override_state_enum_traits` is a string that overrides the new configuration option for a given state machine. This is useful, for example, if you want to provide a custom implementation of one of the standard traits.

 * The attribute `extend_state_enum_traits` is a string that extends the list of derived traits. This is useful, for example, if you want to derive all of the default traits plus some additional traits that are specific to this state machine.

One thing to note is that the new configuration option is Rust-specific, while the existing configuration options are relatively backend-agnostic. Currently, there's not a good place (as far as I know) to put backend-specific configuration options, so the only place it can go is in the global configuration file.