### PR TITLE
Add state transition hook methods

### DIFF
--- a/framec/src/frame_c/default_config.yaml
+++ b/framec/src/frame_c/default_config.yaml
@@ -34,10 +34,8 @@ codegen:
       state_enum_traits: Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord
       transition_method_name: transition
       change_state_method_name: change_state
-      pre_transition_hook_method_name: pre_transition_hook
-      post_transition_hook_method_name: post_transition_hook
-      pre_change_state_hook_method_name: pre_change_state_hook
-      post_change_state_hook_method_name: post_change_state_hook
+      transition_hook_method_name: transition_hook
+      change_state_hook_method_name: change_state_hook
       state_stack_var_name: state_stack
       state_stack_push_method_name: state_stack_push
       state_stack_pop_method_name: state_stack_pop

--- a/framec/src/frame_c/default_config.yaml
+++ b/framec/src/frame_c/default_config.yaml
@@ -34,6 +34,10 @@ codegen:
       state_enum_traits: Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord
       transition_method_name: transition
       change_state_method_name: change_state
+      pre_transition_hook_method_name: pre_transition_hook,
+      post_transition_hook_method_name: post_transition_hook,
+      pre_change_state_hook_method_name: pre_change_state_hook,
+      post_change_state_hook_method_name: post_change_state_hook,
       state_stack_var_name: state_stack
       state_stack_push_method_name: state_stack_push
       state_stack_pop_method_name: state_stack_pop

--- a/framec/src/frame_c/default_config.yaml
+++ b/framec/src/frame_c/default_config.yaml
@@ -34,10 +34,10 @@ codegen:
       state_enum_traits: Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord
       transition_method_name: transition
       change_state_method_name: change_state
-      pre_transition_hook_method_name: pre_transition_hook,
-      post_transition_hook_method_name: post_transition_hook,
-      pre_change_state_hook_method_name: pre_change_state_hook,
-      post_change_state_hook_method_name: post_change_state_hook,
+      pre_transition_hook_method_name: pre_transition_hook
+      post_transition_hook_method_name: post_transition_hook
+      pre_change_state_hook_method_name: pre_change_state_hook
+      post_change_state_hook_method_name: post_change_state_hook
       state_stack_var_name: state_stack
       state_stack_push_method_name: state_stack_push
       state_stack_pop_method_name: state_stack_pop

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -805,8 +805,13 @@ impl RustVisitor {
                 self.indent();
                 self.newline();
                 if self.generate_transition_hook {
+                    self.add_code("let old_state_enum = self.get_current_state_enum();");
+                    self.newline();
+                    self.add_code("let new_state_enum = self.get_state_enum(&new_state)\
+                                  .expect(\"Internal Frame error: new_state is invalid\");");
+                    self.newline();
                     self.add_code(&format!(
-                        "self.{}();",
+                        "self.{}(old_state_enum, new_state_enum);",
                         self.config.transition_hook_method_name.as_ref().unwrap()
                     ));
                     self.newline();
@@ -960,8 +965,13 @@ impl RustVisitor {
                 self.newline();
                 self.newline();
                 if self.generate_change_state_hook {
+                    self.add_code("let old_state_enum = self.get_current_state_enum();");
+                    self.newline();
+                    self.add_code("let new_state_enum = self.get_state_enum(&new_state)\
+                                  .expect(\"Internal Frame error: new_state is invalid\");");
+                    self.newline();
                     self.add_code(&format!(
-                        "self.{}();",
+                        "self.{}(old_state_enum, new_state_enum);",
                         self.config.change_state_hook_method_name.as_ref().unwrap()
                     ));
                     self.newline();

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -817,7 +817,7 @@ impl RustVisitor {
                 self.indent();
                 self.newline();
                 if self.generate_pre_transition_hook {
-                    self.add_code(&format!("{}();", self.config.pre_transition_hook_method_name.as_ref().unwrap()));
+                    self.add_code(&format!("self.{}();", self.config.pre_transition_hook_method_name.as_ref().unwrap()));
                     self.newline();
                 }
                 if self.generate_exit_args {
@@ -876,7 +876,7 @@ impl RustVisitor {
                 if self.generate_post_transition_hook {
                     self.newline();
                     self.add_code(&format!(
-                        "{}();",
+                        "self.{}();",
                         self.config.post_transition_hook_method_name.as_ref().unwrap()
                     ));
                 }
@@ -977,7 +977,7 @@ impl RustVisitor {
                 self.newline();
                 if self.generate_pre_change_state_hook {
                     self.add_code(&format!(
-                        "{}();",
+                        "self.{}();",
                         self.config.pre_change_state_hook_method_name.as_ref().unwrap()
                     ));
                     self.newline();
@@ -994,7 +994,7 @@ impl RustVisitor {
                 ));
                 if self.generate_post_change_state_hook {
                     self.add_code(&format!(
-                        "{}();",
+                        "self.{}();",
                         self.config.post_change_state_hook_method_name.as_ref().unwrap()
                     ));
                     self.newline();

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -701,7 +701,7 @@ impl RustVisitor {
         if self.config.config_features.introspection {
             self.newline();
             self.add_code(&format!(
-                "pub fn get_{}_enum(&self, state: &{}) -> Option<{}{}> {{",
+                "pub fn get_{}_enum(&self, state: {}) -> Option<{}{}> {{",
                 self.config.state_var_name,
                 self.config.frame_state_type_name,
                 self.system_name,
@@ -753,11 +753,10 @@ impl RustVisitor {
             self.indent();
             self.newline();
             self.add_code(&format!(
-                "self.get_{}_enum(&self.state)",
+                "self.get_{}_enum(self.state)",
                 self.config.state_var_name
             ));
-            self.newline();
-            self.add_code(&format!("    .expect(\"Machine in invalid state.\")"));
+            self.add_code(&format!(".expect(\"Machine in invalid state.\")"));
             self.outdent();
             self.newline();
             self.add_code("}");
@@ -807,7 +806,7 @@ impl RustVisitor {
                 if self.generate_transition_hook {
                     self.add_code("let old_state_enum = self.get_current_state_enum();");
                     self.newline();
-                    self.add_code("let new_state_enum = self.get_state_enum(&new_state)\
+                    self.add_code("let new_state_enum = self.get_state_enum(new_state)\
                                   .expect(\"Internal Frame error: new_state is invalid\");");
                     self.newline();
                     self.add_code(&format!(
@@ -967,7 +966,7 @@ impl RustVisitor {
                 if self.generate_change_state_hook {
                     self.add_code("let old_state_enum = self.get_current_state_enum();");
                     self.newline();
-                    self.add_code("let new_state_enum = self.get_state_enum(&new_state)\
+                    self.add_code("let new_state_enum = self.get_state_enum(new_state)\
                                   .expect(\"Internal Frame error: new_state is invalid\");");
                     self.newline();
                     self.add_code(&format!(

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -46,6 +46,10 @@ struct Config {
     state_enum_traits: String,
     transition_method_name: String,
     change_state_method_name: String,
+    pre_transition_hook_method_name: String,
+    post_transition_hook_method_name: String,
+    pre_change_state_hook_method_name: String,
+    post_change_state_hook_method_name: String,
     state_stack_push_method_name: String,
     state_stack_pop_method_name: String,
 }
@@ -181,6 +185,22 @@ impl Config {
                 .unwrap_or_default()
                 .to_string(),
             change_state_method_name: (&code_yaml["change_state_method_name"])
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+            pre_transition_hook_method_name: (&code_yaml["pre_transition_hook_method_name"])
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+            post_transition_hook_method_name: (&code_yaml["post_transition_hook_method_name"])
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+            pre_change_state_hook_method_name: (&code_yaml["pre_change_state_hook_method_name"])
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+            post_change_state_hook_method_name: (&code_yaml["post_change_state_hook_method_name"])
                 .as_str()
                 .unwrap_or_default()
                 .to_string(),

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -804,10 +804,16 @@ impl RustVisitor {
                 self.indent();
                 self.newline();
                 if self.generate_transition_hook {
-                    self.add_code("let old_state_enum = self.get_current_state_enum();");
+                    self.add_code(&format!(
+                        "let old_state_enum = self.get_current_{}_enum();",
+                        self.config.state_var_name
+                    ));
                     self.newline();
-                    self.add_code("let new_state_enum = self.get_state_enum(new_state)\
-                                  .expect(\"Internal Frame error: new_state is invalid\");");
+                    self.add_code(&format!(
+                        "let new_state_enum = self.get_{}_enum(new_state)\
+                            .expect(\"Internal Frame error: transition to invalid new_state\");",
+                        self.config.state_var_name
+                    ));
                     self.newline();
                     self.add_code(&format!(
                         "self.{}(old_state_enum, new_state_enum);",
@@ -964,10 +970,16 @@ impl RustVisitor {
                 self.newline();
                 self.newline();
                 if self.generate_change_state_hook {
-                    self.add_code("let old_state_enum = self.get_current_state_enum();");
+                    self.add_code(&format!(
+                        "let old_state_enum = self.get_current_{}_enum();",
+                        self.config.state_var_name
+                    ));
                     self.newline();
-                    self.add_code("let new_state_enum = self.get_state_enum(new_state)\
-                                  .expect(\"Internal Frame error: new_state is invalid\");");
+                    self.add_code(&format!(
+                        "let new_state_enum = self.get_{}_enum(new_state)\
+                            .expect(\"Internal Frame error: change_state to invalid new_state\");",
+                        self.config.state_var_name
+                    ));
                     self.newline();
                     self.add_code(&format!(
                         "self.{}(old_state_enum, new_state_enum);",

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -46,10 +46,8 @@ struct Config {
     state_enum_traits: String,
     transition_method_name: String,
     change_state_method_name: String,
-    pre_transition_hook_method_name: Option<String>,
-    post_transition_hook_method_name: Option<String>,
-    pre_change_state_hook_method_name: Option<String>,
-    post_change_state_hook_method_name: Option<String>,
+    transition_hook_method_name: Option<String>,
+    change_state_hook_method_name: Option<String>,
     state_stack_push_method_name: String,
     state_stack_pop_method_name: String,
 }
@@ -188,16 +186,10 @@ impl Config {
                 .as_str()
                 .unwrap_or_default()
                 .to_string(),
-            pre_transition_hook_method_name: (&code_yaml["pre_transition_hook_method_name"])
+            transition_hook_method_name: (&code_yaml["transition_hook_method_name"])
                 .as_str()
                 .map(|s| s.to_string()),
-            post_transition_hook_method_name: (&code_yaml["post_transition_hook_method_name"])
-                .as_str()
-                .map(|s| s.to_string()),
-            pre_change_state_hook_method_name: (&code_yaml["pre_change_state_hook_method_name"])
-                .as_str()
-                .map(|s| s.to_string()),
-            post_change_state_hook_method_name: (&code_yaml["post_change_state_hook_method_name"])
+            change_state_hook_method_name: (&code_yaml["change_state_hook_method_name"])
                 .as_str()
                 .map(|s| s.to_string()),
             state_stack_push_method_name: (&code_yaml["state_stack_push_method_name"])
@@ -237,10 +229,8 @@ pub struct RustVisitor {
     generate_state_stack: bool,
     generate_change_state: bool,
     generate_transition_state: bool,
-    generate_pre_transition_hook: bool,
-    generate_post_transition_hook: bool,
-    generate_pre_change_state_hook: bool,
-    generate_post_change_state_hook: bool,
+    generate_transition_hook: bool,
+    generate_change_state_hook: bool,
     current_message: String,
 }
 
@@ -284,10 +274,8 @@ impl RustVisitor {
             generate_state_stack,
             generate_change_state,
             generate_transition_state,
-            generate_pre_transition_hook: config.pre_transition_hook_method_name.is_some(),
-            generate_post_transition_hook: config.post_transition_hook_method_name.is_some(),
-            generate_pre_change_state_hook: config.pre_change_state_hook_method_name.is_some(),
-            generate_post_change_state_hook: config.post_change_state_hook_method_name.is_some(),
+            generate_transition_hook: config.transition_hook_method_name.is_some(),
+            generate_change_state_hook: config.change_state_hook_method_name.is_some(),
             current_message: String::new(),
             config,
         }
@@ -816,8 +804,11 @@ impl RustVisitor {
                 }
                 self.indent();
                 self.newline();
-                if self.generate_pre_transition_hook {
-                    self.add_code(&format!("self.{}();", self.config.pre_transition_hook_method_name.as_ref().unwrap()));
+                if self.generate_transition_hook {
+                    self.add_code(&format!(
+                        "self.{}();",
+                        self.config.transition_hook_method_name.as_ref().unwrap()
+                    ));
                     self.newline();
                 }
                 if self.generate_exit_args {
@@ -873,13 +864,6 @@ impl RustVisitor {
                     "(self.{})(self, &mut enter_event);",
                     &self.config.state_var_name
                 ));
-                if self.generate_post_transition_hook {
-                    self.newline();
-                    self.add_code(&format!(
-                        "self.{}();",
-                        self.config.post_transition_hook_method_name.as_ref().unwrap()
-                    ));
-                }
                 self.outdent();
                 self.newline();
                 self.add_code(&format!("}}"));
@@ -975,10 +959,10 @@ impl RustVisitor {
             if self.generate_change_state {
                 self.newline();
                 self.newline();
-                if self.generate_pre_change_state_hook {
+                if self.generate_change_state_hook {
                     self.add_code(&format!(
                         "self.{}();",
-                        self.config.pre_change_state_hook_method_name.as_ref().unwrap()
+                        self.config.change_state_hook_method_name.as_ref().unwrap()
                     ));
                     self.newline();
                 }
@@ -992,13 +976,6 @@ impl RustVisitor {
                     "self.{} = new_state;",
                     &self.config.state_var_name
                 ));
-                if self.generate_post_change_state_hook {
-                    self.add_code(&format!(
-                        "self.{}();",
-                        self.config.post_change_state_hook_method_name.as_ref().unwrap()
-                    ));
-                    self.newline();
-                }
 
                 self.outdent();
                 self.newline();

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -274,8 +274,10 @@ impl RustVisitor {
             generate_state_stack,
             generate_change_state,
             generate_transition_state,
-            generate_transition_hook: config.transition_hook_method_name.is_some(),
-            generate_change_state_hook: config.change_state_hook_method_name.is_some(),
+            generate_transition_hook: config.config_features.introspection
+                && config.transition_hook_method_name.is_some(),
+            generate_change_state_hook: config.config_features.introspection
+                && config.change_state_hook_method_name.is_some(),
             current_message: String::new(),
             config,
         }


### PR DESCRIPTION
This adds a way to generate a call to a "hook" method on every state transition. The hook method is just an arbitrary method that will be invoked on every state transition.

Currently, it calls a different hook method calls depending on whether the state changed via the `transition` method or via the `change_state` method.

The names of the hook methods can be specified using two new configuration options:
 * `transition_hook_method_name`
 * `change_state_hook_method_name`

If either of these options is not present or is left blank (or if `introspection` is disabled, see below), calls to the corresponding hook method will not be generated. Therefore, this feature is completely optional.

The hook methods take as arguments the state enum values corresponding to the states before and after the transition. Therefore, this feature is dependent on the `introspection` configuration feature option.

Here's an example of how to define hook method and put it in the expected place.

```rust
// Include the Rust file generated by Frame.
include!(concat!(env!("OUT_DIR"), "/", "src/state_machines/MyMachine.rs"));

// Add methods to my state machine.
impl MyMachine {

    // This method will be called on every transition.
    pub fn transition_hook(&self, old_state: MyMachineState, new_state: MyMachineState) {
        println!("transition from {:?} to {:?}", old_state, new_state);
    }

}
```

This assumes that the configuration file contains the following entries:

```yaml
codegen:
  rust:
    features:
      introspection: true
      ...
    code:
      transition_hook_method_name: transition_hook
      ...
```

**Note:** This pull request also fixes a bug in the introspection feature that I introduced in #5 (sorry about that!). 