### PR TITLE
Generate Enter event when entering initial state

### DIFF
--- a/framec/src/frame_c/default_config.yaml
+++ b/framec/src/frame_c/default_config.yaml
@@ -40,6 +40,7 @@ codegen:
       state_var_name_suffix: _state
       state_enum_suffix: State
       state_enum_traits: Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord
+      initialize_method_name: initialize
       transition_method_name: transition
       change_state_method_name: change_state
       transition_hook_method_name: transition_hook

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -2167,7 +2167,6 @@ impl AstVisitor for RustVisitor {
         }
 
         if self.has_states {
-
             // generate constructor
 
             self.newline();
@@ -2278,7 +2277,7 @@ impl AstVisitor for RustVisitor {
             self.newline();
             self.add_code("}");
             self.newline();
-        
+
             // end of generate constructor
 
             // generate initialize method

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -899,22 +899,14 @@ impl RustVisitor {
                         &self.config.state_context_var_name, &self.config.state_context_var_name
                     ));
                     self.newline();
-                    self.add_code(&format!(
-                        "let mut enter_event = {}::new({}::{}, None);",
-                        self.config.frame_event_type_name,
-                        self.config.frame_event_message_type_name,
-                        self.config.enter_msg
-                    ));
-                    self.newline();
-                } else {
-                    self.add_code(&format!(
-                        "let mut enter_event = {}::new({}::{}, None);",
-                        self.config.frame_event_type_name,
-                        self.config.frame_event_message_type_name,
-                        self.config.enter_msg
-                    ));
-                    self.newline();
                 }
+                self.add_code(&format!(
+                    "let mut enter_event = {}::new({}::{}, None);",
+                    self.config.frame_event_type_name,
+                    self.config.frame_event_message_type_name,
+                    self.config.enter_msg
+                ));
+                self.newline();
                 self.add_code(&format!(
                     "(self.{})(self, &mut enter_event);",
                     &self.config.state_var_name
@@ -2217,7 +2209,7 @@ impl AstVisitor for RustVisitor {
             }
 
             self.newline();
-            self.add_code(&format!("{} {{", system_node.name));
+            self.add_code(&format!("let mut machine = {} {{", system_node.name));
             self.indent();
             self.newline();
             self.add_code(&format!(
@@ -2262,10 +2254,30 @@ impl AstVisitor for RustVisitor {
 
             self.outdent();
             self.newline();
-            self.add_code(&format!("}}"));
+            self.add_code("};");
+            self.newline();
+            
+            // send enter event for initial state
+            self.add_code(&format!(
+                "let mut enter_event = {}::new({}::{}, None);",
+                self.config.frame_event_type_name,
+                self.config.frame_event_message_type_name,
+                self.config.enter_msg
+            ));
+            self.newline();
+            self.add_code(&format!(
+                "{}::{}(&mut machine, &mut enter_event);",
+                system_node.name,
+                self.format_state_name(&self.first_state_name)
+            ));
+            self.newline();
+
+            // return the new machine
+            self.add_code("machine");
+
             self.outdent();
             self.newline();
-            self.add_code(&format!("}}"));
+            self.add_code("}");
             self.newline();
         }
 

--- a/framec_tests/src/basic.rs
+++ b/framec_tests/src/basic.rs
@@ -18,10 +18,9 @@ mod tests {
     // Revisit: currently generated code doesn't send entry event to state machine's initial
     // state on creation
     #[test]
-    #[ignore]
     fn intial_state_entry_call() {
         let sm = Basic::new();
-        assert_eq!(sm.entry_log, vec!["S1"]);
+        assert_eq!(sm.entry_log, vec!["S0"]);
     }
 
     #[test]


### PR DESCRIPTION
This fixes a bug where no `Enter` event was being generated when entering the initial state.

A new `initialize()` method has been added to the state machine (the name of the method is configurable with the new `initialize_method_name` configuration option). This method is called from the state machine's constructor and currently just sends an `Enter` event to the initial state.

Putting such initialization work in a new method (rather than in the constructor directly) makes it easier to write custom constructors for state machines.

This fixes one of the previously failing/ignored tests added by @fdlg in #13.