### PR TITLE
Refactor Rust backend to use simpler state representation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 *.idea
 *.iml
 
+config.yaml
+framec_tests/config.yaml
 target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "atty"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
 
 [[package]]
 name = "bumpalo"
@@ -60,6 +60,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +87,7 @@ checksum = "fe56556a8c9f9f556150eb6b390bc1a8b3715fd2ddbb4585f36b6a5672c6a833"
 name = "framec"
 version = "0.5.1"
 dependencies = [
+ "convert_case",
  "downcast-rs",
  "exitcode",
  "fomat-macros",
@@ -124,9 +131,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "linked-hash-map"

--- a/framec/Cargo.toml
+++ b/framec/Cargo.toml
@@ -9,12 +9,13 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-wasm-bindgen="0.2"
+convert_case = "0.4.0"
 downcast-rs = "1.2.0"
-# runtime-fmt = "0.4.1"
-fomat-macros = "0.3.1"
-structopt = "0.3.21"
 exitcode = "1.1.2"
+fomat-macros = "0.3.1"
+# runtime-fmt = "0.4.1"
+structopt = "0.3.21"
+wasm-bindgen = "0.2"
 yaml-rust = "0.4.5"
 
 [package.metadata.wasm-pack.profile.release]

--- a/framec/src/frame_c/default_config.yaml
+++ b/framec/src/frame_c/default_config.yaml
@@ -22,7 +22,6 @@ codegen:
       state_context_suffix: StateContext
       state_context_var_name: state_context_rc
       state_context_var_name_suffix: _state_context
-      state_context_struct_name: StateContext
       this_state_context_var_name: this_state_context
       frame_event_message_type_name: FrameMessage
       frame_event_type_name: FrameEvent

--- a/framec/src/frame_c/default_config.yaml
+++ b/framec/src/frame_c/default_config.yaml
@@ -6,7 +6,7 @@ codegen:
   rust:
     features:
       generate_action_impl: true
-      lower_case_methods: true
+      follow_rust_naming: true
     code:
       actions_prefix:
       actions_suffix: Actions

--- a/framec/src/frame_c/default_config.yaml
+++ b/framec/src/frame_c/default_config.yaml
@@ -20,8 +20,8 @@ codegen:
       state_vars_var_name: state_vars
       state_context_name: StateContext
       state_context_suffix: StateContext
-      state_context_var_name: state_context_rc
-      state_context_var_name_suffix: _state_context
+      state_context_var_name: state_context
+      state_context_method_suffix: _context
       this_state_context_var_name: this_state_context
       frame_event_message_type_name: FrameMessage
       frame_event_type_name: FrameEvent

--- a/framec/src/frame_c/default_config.yaml
+++ b/framec/src/frame_c/default_config.yaml
@@ -5,9 +5,8 @@ codegen:
 
   rust:
     features:
-      lower_case_states: false
-      introspection: true
       generate_action_impl: true
+      lower_case_methods: true
     code:
       actions_prefix:
       actions_suffix: Actions
@@ -34,13 +33,13 @@ codegen:
       frame_event_parameters_attribute_name: parameters
       frame_event_message_attribute_name: message
       frame_event_return_attribute_name: ret
-      frame_state_type_name: FrameState
       state_var_name: state
-      state_var_name_prefix:
-      state_var_name_suffix: _state
+      state_handler_name_prefix:
+      state_handler_name_suffix: _handler
       state_enum_suffix: State
       state_enum_traits: Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord
       initialize_method_name: initialize
+      handle_event_method_name: handle_event
       transition_method_name: transition
       change_state_method_name: change_state
       transition_hook_method_name: transition_hook

--- a/framec/src/frame_c/default_config.yaml
+++ b/framec/src/frame_c/default_config.yaml
@@ -28,7 +28,7 @@ codegen:
       frame_event_parameter_type_name: FrameEventParameter
       frame_event_parameters_type_name: FrameEventParameters
       frame_event_return: FrameEventReturn
-      frame_event_variable_name: e
+      frame_event_variable_name: frame_event
       frame_event_parameters_attribute_name: parameters
       frame_event_message_attribute_name: message
       frame_event_return_attribute_name: ret

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -822,8 +822,10 @@ impl RustVisitor {
                 match &state_node.params_opt {
                     Some(params) => {
                         has_state_args = true;
-                        self.indent();
+                        self.add_code("#[allow(dead_code)]");
+                        self.newline();
                         self.add_code(&format!("struct {}StateArgs {{", state_node.name));
+                        self.indent();
                         for param in params {
                             let param_type = match &param.param_type_opt {
                                 Some(param_type) => param_type.get_type_str(),
@@ -849,6 +851,8 @@ impl RustVisitor {
                 match &state_node.vars_opt {
                     Some(var_decl_nodes) => {
                         has_state_vars = true;
+                        self.add_code("#[allow(dead_code)]");
+                        self.newline();
                         self.add_code(&format!("struct {}StateVars {{", state_node.name));
                         self.indent();
                         // self.add_code(&format!("{}: (",self.config.enter_arg_prefix));
@@ -882,6 +886,8 @@ impl RustVisitor {
                         match &event_symbol.params_opt {
                             Some(params) => {
                                 has_enter_event_params = true;
+                                self.add_code("#[allow(dead_code)]");
+                                self.newline();
                                 self.add_code(&format!("struct {}EnterArgs {{", state_node.name));
                                 self.indent();
                                 for param in params {
@@ -908,6 +914,8 @@ impl RustVisitor {
                 }
 
                 // generate state context struct for this state
+                self.add_code("#[allow(dead_code)]");
+                self.newline();
                 self.add_code(&format!(
                     "struct {} {{",
                     self.format_state_context_struct_name(&state_node.name)
@@ -945,6 +953,8 @@ impl RustVisitor {
             }
 
             // generate the enum type that unions all the state context types
+            self.add_code("#[allow(dead_code)]");
+            self.newline();
             self.add_code(&format!("enum {} {{", self.config.state_context_name));
             self.indent();
             for state in &machine_block_node.states {
@@ -964,6 +974,8 @@ impl RustVisitor {
 
             // generate methods to conveniently get specific state contexts
             // from a value of the enum type
+            self.add_code("#[allow(dead_code)]");
+            self.newline();
             self.add_code(&format!("impl {} {{", self.config.state_context_name));
             self.indent();
             for state in &machine_block_node.states {
@@ -2900,6 +2912,8 @@ impl AstVisitor for RustVisitor {
         self.add_code("#[allow(unused_mut)]");
         self.newline();
         self.add_code("#[allow(unused_parens)]");
+        self.newline();
+        self.add_code("#[allow(unused_variables)]");
         self.newline();
         self.add_code(&format!(
             "fn {}(&mut self, {}: &mut {}) {{",

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -330,14 +330,13 @@ impl RustVisitor {
     //* --------------------------------------------------------------------- *//
 
     pub fn get_msg_enum(&self, msg: &str) -> String {
-        let unformatted =
-            match msg {
-                // ">>" => self.config.start_system_msg.clone(),
-                // "<<" => self.config.stop_system_msg.clone(),
-                ">" => self.config.enter_msg.clone(),
-                "<" => self.config.exit_msg.clone(),
-                _ => self.arcanium.get_interface_or_msg_from_msg(msg).unwrap(),
-            };
+        let unformatted = match msg {
+            // ">>" => self.config.start_system_msg.clone(),
+            // "<<" => self.config.stop_system_msg.clone(),
+            ">" => self.config.enter_msg.clone(),
+            "<" => self.config.exit_msg.clone(),
+            _ => self.arcanium.get_interface_or_msg_from_msg(msg).unwrap(),
+        };
         self.format_type_name(&unformatted)
     }
 
@@ -364,24 +363,23 @@ impl RustVisitor {
         param_name: &str,
     ) -> String {
         let (state_name_opt, event_name) = self.parse_event_name(&unparsed_event_name);
-        let unformatted_name =
-            match &state_name_opt {
-                Some(state_name) => format!(
-                    "{}_{}_{}",
-                    state_name,
-                    &*self.canonical_event_name(&event_name),
-                    param_name
-                ),
-                None => {
-                    let message_opt = self.arcanium.get_interface_or_msg_from_msg(&event_name);
-                    match &message_opt {
-                        Some(canonical_message_name) => {
-                            format!("{}_{}", canonical_message_name, param_name)
-                        }
-                        None => format!("<Error - unknown message {}>,", &unparsed_event_name),
+        let unformatted_name = match &state_name_opt {
+            Some(state_name) => format!(
+                "{}_{}_{}",
+                state_name,
+                &*self.canonical_event_name(&event_name),
+                param_name
+            ),
+            None => {
+                let message_opt = self.arcanium.get_interface_or_msg_from_msg(&event_name);
+                match &message_opt {
+                    Some(canonical_message_name) => {
+                        format!("{}_{}", canonical_message_name, param_name)
                     }
+                    None => format!("<Error - unknown message {}>,", &unparsed_event_name),
                 }
-            };
+            }
+        };
         self.format_value_name(&unformatted_name)
     }
 
@@ -624,7 +622,7 @@ impl RustVisitor {
     fn format_getter_name(&self, member_name: &str) -> String {
         format!("get_{}", self.format_value_name(&member_name.to_string()))
     }
-    
+
     fn format_setter_name(&self, member_name: &str) -> String {
         format!("set_{}", self.format_value_name(&member_name.to_string()))
     }
@@ -632,12 +630,14 @@ impl RustVisitor {
     fn format_event_param_getter(&self, message_name: &str, param_name: &str) -> String {
         self.format_getter_name(&format!("{}_{}", message_name, param_name))
     }
-    
-    fn format_exit_param_getter(&self, state_name: &str, message_name: &str, param_name: &str) -> String {
-        self.format_getter_name(&format!(
-            "{}_{}_{}",
-            state_name, message_name, param_name
-        ))
+
+    fn format_exit_param_getter(
+        &self,
+        state_name: &str,
+        message_name: &str,
+        param_name: &str,
+    ) -> String {
+        self.format_getter_name(&format!("{}_{}_{}", state_name, message_name, param_name))
     }
 
     fn format_state_context_method_name(&self, state_name: &str) -> String {
@@ -834,7 +834,8 @@ impl RustVisitor {
                             self.newline();
                             self.add_code(&format!(
                                 "{}: {},",
-                                self.format_value_name(&param.param_name), param_type
+                                self.format_value_name(&param.param_name),
+                                param_type
                             ));
                         }
                         self.outdent();
@@ -898,7 +899,8 @@ impl RustVisitor {
                                     self.newline();
                                     self.add_code(&format!(
                                         "{}: {},",
-                                        self.format_value_name(&param.name), &param_type
+                                        self.format_value_name(&param.name),
+                                        &param_type
                                     ));
                                 }
                                 self.outdent();
@@ -994,7 +996,8 @@ impl RustVisitor {
                 self.newline();
                 self.add_code(&format!(
                     "{}::{}(context) => context,",
-                    self.config.state_context_name, self.format_type_name(&state_node.name)
+                    self.config.state_context_name,
+                    self.format_type_name(&state_node.name)
                 ));
                 self.newline();
                 self.add_code(&format!(
@@ -1870,7 +1873,7 @@ impl RustVisitor {
                         Some(event_params) => {
                             if exit_args.exprs_t.len() != event_params.len() {
                                 self.errors.push(
-                                    "Fatal error: misaligned parameters to arguments.".to_string()
+                                    "Fatal error: misaligned parameters to arguments.".to_string(),
                                 );
                             }
                             let mut param_symbols_it = event_params.iter();
@@ -2023,14 +2026,15 @@ impl AstVisitor for RustVisitor {
                                         None => "<?>".to_string().clone(),
                                     };
                                     self.newline();
-                                    let parameter_enum_name =
-                                        self.format_frame_event_parameter_name(
+                                    let parameter_enum_name = self
+                                        .format_frame_event_parameter_name(
                                             &event_sym.borrow().msg,
                                             &param.name,
                                         );
                                     self.add_code(&format!(
                                         "{} {{ param: {} }},",
-                                        self.format_type_name(&parameter_enum_name), param_type
+                                        self.format_type_name(&parameter_enum_name),
+                                        param_type
                                     ));
                                 }
                             }
@@ -2354,7 +2358,10 @@ impl AstVisitor for RustVisitor {
             match message_opt {
                 Some(canonical_message_name) => {
                     self.newline();
-                    self.add_code(&format!("{},", self.format_type_name(&canonical_message_name)));
+                    self.add_code(&format!(
+                        "{},",
+                        self.format_type_name(&canonical_message_name)
+                    ));
                 }
                 None => {
                     self.newline();
@@ -2513,7 +2520,8 @@ impl AstVisitor for RustVisitor {
                                     self.add_code(&format!(
                                         "fn {}(&mut self, {}: {}) {{",
                                         self.format_setter_name(&parameter_enum_name),
-                                        param.name, param_type
+                                        param.name,
+                                        param_type
                                     ));
                                     self.indent();
                                     self.newline();
@@ -2710,7 +2718,8 @@ impl AstVisitor for RustVisitor {
                         self.newline();
                         self.add_code(&format!(
                             "(*frame_parameters).{}({});",
-                            self.format_setter_name(&parameter_enum_name), pname
+                            self.format_setter_name(&parameter_enum_name),
+                            pname
                         ));
                     }
                 }
@@ -2739,8 +2748,7 @@ impl AstVisitor for RustVisitor {
         self.newline();
         self.add_code(&format!(
             "self.{}(&mut {});",
-            self.config.handle_event_method_name,
-            self.config.frame_event_variable_name,
+            self.config.handle_event_method_name, self.config.frame_event_variable_name,
         ));
 
         match &interface_method_node.return_type_opt {

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -1199,17 +1199,18 @@ impl RustVisitor {
         self.add_code(&format!("match self.{} {{", self.config.state_var_name));
         if let Some(machine_block_node) = &system_node.machine_block_node_opt {
             self.indent();
-            self.newline();
             for state in &machine_block_node.states {
+                self.newline();
                 self.add_code(&format!(
                     "{}::{} => self.{}(e),", // TODO need to deal with states w/ arguments
                     self.state_enum_type_name(),
                     &state.borrow().name,
                     self.format_state_handler_name(&state.borrow().name)
                 ));
-                self.newline();
             }
         }
+        self.outdent();
+        self.newline();
         self.add_code("}");
         self.outdent();
         self.newline();

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -32,7 +32,6 @@ struct Config {
     state_context_suffix: String,
     state_context_var_name: String,
     state_context_method_suffix: String,
-    state_context_struct_name: String,
     this_state_context_var_name: String,
     frame_event_message_type_name: String,
     frame_event_type_name: String,
@@ -143,10 +142,6 @@ impl Config {
                 .unwrap_or_default()
                 .to_string(),
             state_context_method_suffix: (&code_yaml["state_context_method_suffix"])
-                .as_str()
-                .unwrap_or_default()
-                .to_string(),
-            state_context_struct_name: (&code_yaml["state_context_struct_name"])
                 .as_str()
                 .unwrap_or_default()
                 .to_string(),
@@ -2227,7 +2222,7 @@ impl AstVisitor for RustVisitor {
             self.newline();
             self.add_code(&format!(
                 "{}: Rc<RefCell<{}>>,",
-                self.config.state_context_var_name, self.config.state_context_struct_name
+                self.config.state_context_var_name, self.config.state_context_name
             ));
             if self.generate_state_stack {
                 self.newline();

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -2043,9 +2043,13 @@ impl AstVisitor for RustVisitor {
         self.outdent();
         self.newline();
         self.add_code("}");
-        self.newline();
-        self.newline();
 
+        self.newline();
+        self.newline();
+        self.add_code("#[allow(dead_code)]");
+        self.newline();
+        self.add_code("#[allow(non_snake_case)]");
+        self.newline();
         self.add_code(&format!("impl {} {{", self.config.frame_event_return));
         if let Some(interface_block_node) = &system_node.interface_block_node_opt {
             for interface_method_node in &interface_block_node.interface_methods {
@@ -2140,8 +2144,6 @@ impl AstVisitor for RustVisitor {
         self.outdent();
         self.newline();
         self.add_code("}");
-        self.newline();
-        self.newline();
 
         self.newline();
         self.newline();
@@ -2214,9 +2216,9 @@ impl AstVisitor for RustVisitor {
         self.newline();
         self.newline();
 
-        self.add_code("#[allow(non_snake_case)]");
-        self.newline();
         self.add_code("#[allow(dead_code)]");
+        self.newline();
+        self.add_code("#[allow(non_snake_case)]");
         self.newline();
         self.add_code(&format!("impl {} {{", system_node.name));
         self.indent();
@@ -4237,15 +4239,15 @@ impl AstVisitor for RustVisitor {
         variable_decl_node: &VariableDeclNode,
     ) -> AstVisitorReturnType {
         let var_type = match &variable_decl_node.type_opt {
-            Some(x) => x.get_type_str(),
-            None => String::from("<?>"),
+            Some(x) => format!(": {}", x.get_type_str()),
+            None => String::new(),
         };
         let var_name = &variable_decl_node.name;
         let var_init_expr = &variable_decl_node.initializer_expr_t_opt.as_ref().unwrap();
         self.newline();
         let mut code = String::new();
         var_init_expr.accept_to_string(self, &mut code);
-        self.add_code(&format!("let {}: {} = {};", var_name, var_type, code));
+        self.add_code(&format!("let {}{} = {};", var_name, var_type, code));
 
         // currently unused serialization code
         // self.serialize.push(format!("\tbag.domain[\"{}\"] = {};",var_name,var_name));

--- a/framec_tests/src/basic.rs
+++ b/framec_tests/src/basic.rs
@@ -15,8 +15,6 @@ impl Basic {
 mod tests {
     use super::*;
 
-    // Revisit: currently generated code doesn't send entry event to state machine's initial
-    // state on creation
     #[test]
     fn intial_state_entry_call() {
         let sm = Basic::new();

--- a/framec_tests/src/basic.rs
+++ b/framec_tests/src/basic.rs
@@ -27,24 +27,24 @@ mod tests {
     fn non_initial_state_entry_calls() {
         let mut sm = Basic::new();
         sm.entry_log.clear();
-        sm.A();
-        sm.B();
+        sm.a();
+        sm.b();
         assert_eq!(sm.entry_log, vec!["S1", "S0"]);
     }
     #[test]
     fn exit_calls() {
         let mut sm = Basic::new();
-        sm.A();
-        sm.B();
+        sm.a();
+        sm.b();
         assert_eq!(sm.exit_log, vec!["S0", "S1"]);
     }
     #[test]
     fn current_state() {
         let mut sm = Basic::new();
-        assert_eq!(sm.get_current_state_enum(), BasicState::S0);
-        sm.A();
-        assert_eq!(sm.get_current_state_enum(), BasicState::S1);
-        sm.B();
-        assert_eq!(sm.get_current_state_enum(), BasicState::S0);
+        assert_eq!(sm.state, BasicState::S0);
+        sm.a();
+        assert_eq!(sm.state, BasicState::S1);
+        sm.b();
+        assert_eq!(sm.state, BasicState::S0);
     }
 }

--- a/framec_tests/src/empty.frm
+++ b/framec_tests/src/empty.frm
@@ -1,0 +1,6 @@
+#Empty
+    -interface-
+    -machine-
+    -actions-
+    -domain-
+##

--- a/framec_tests/src/empty.rs
+++ b/framec_tests/src/empty.rs
@@ -1,0 +1,10 @@
+include!(concat!(env!("OUT_DIR"), "/", "empty.rs"));
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn empty_state_machine_compiles() {
+        assert!(true);
+    }
+}

--- a/framec_tests/src/event_handler.frm
+++ b/framec_tests/src/event_handler.frm
@@ -1,0 +1,44 @@
+#EventHandler
+    -interface-
+    LogIt [x:i32]
+    LogAdd [a:i32 b:i32]
+    LogReturn [a:i32 b:i32] : i32
+    PassAdd [a:i32 b:i32]
+    PassReturn [a:i32 b:i32] : i32
+
+    -machine-
+    $S1
+        |LogIt| [x:i32]
+            log("x" x) ^
+        
+        |LogAdd| [a:i32 b:i32]
+            log("a" a)
+            log("b" b)
+            log("a+b" a+b) ^
+        
+        |LogReturn| [a:i32 b:i32]
+            log("a" a)
+            log("b" b)
+            var r = a + b
+            log("r" r)
+            -> ^(r)
+        
+        |PassAdd| [a:i32 b:i32]
+            -> $S2(a+b) ^
+        
+        |PassReturn| [a:i32 b:i32]
+            var r = a + b
+            log("r" r)
+            -> $S2(r) ^(r)
+
+    $S2 [p:i32]
+        
+        |>|
+            log("p" p) ^
+
+    -actions-
+    log [val:i32]
+    
+    -domain-
+    var tape:Log = `vec![]`
+##

--- a/framec_tests/src/event_handler.rs
+++ b/framec_tests/src/event_handler.rs
@@ -1,0 +1,53 @@
+//! Test event handler parameters, local variables, and return values.
+
+type Log = Vec<String>;
+include!(concat!(env!("OUT_DIR"), "/", "event_handler.rs"));
+
+impl EventHandler {
+    pub fn log(&mut self, msg: String, val: i32) {
+        self.tape.push(format!("{}={}", msg, val));
+    }
+    pub fn transition_hook(&mut self, _current: EventHandlerState, _next: EventHandlerState) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_parameter() {
+        let mut sm = EventHandler::new();
+        sm.log_it(2);
+        assert_eq!(sm.tape, vec!["x=2"]);
+    }
+
+    #[test]
+    fn compute_two_parameters() {
+        let mut sm = EventHandler::new();
+        sm.log_add(-3, 10);
+        assert_eq!(sm.tape, vec!["a=-3", "b=10", "a+b=7"]);
+    }
+
+    #[test]
+    fn return_local_variable() {
+        let mut sm = EventHandler::new();
+        let ret = sm.log_return(13, 21);
+        assert_eq!(sm.tape, vec!["a=13", "b=21", "r=34"]);
+        assert_eq!(ret, 34);
+    }
+
+    #[test]
+    fn pass_result() {
+        let mut sm = EventHandler::new();
+        sm.pass_add(5, -12);
+        assert_eq!(sm.tape, vec!["p=-7"]);
+    }
+
+    #[test]
+    fn pass_and_return_result() {
+        let mut sm = EventHandler::new();
+        let ret = sm.pass_return(101, -59);
+        assert_eq!(sm.tape, vec!["r=42", "p=42"]);
+        assert_eq!(ret, 42);
+    }
+}

--- a/framec_tests/src/event_params.frm
+++ b/framec_tests/src/event_params.frm
@@ -1,33 +1,25 @@
 #EventParams
     -interface-
-    Hello
-    Goodbye
-    Both
+    Next
     
     -machine-
+    $Init
+        |>|
+            -> ("hi A" 1) $A ^
+
     $A
         |>| [msg:String val:i16]
-            entered(msg val) ^
-        |<| [val:bool msg:String]
-            exited(val msg) ^
-        |Hello|
-            -> ("hello B" 42) $B ^
-        |Goodbye|
-            (true "goodbye A") -> $B ^
-        |Both|
-            (false "bye A") -> ("hi B" -42) $B ^
+            entered(msg.clone() val) ^
+        |Next|
+            -> ("hi B" 2) $B ^
 
     $B
         |>| [msg:String val:i16]
-            entered(msg val) ^
+            entered(msg.clone() val) ^
         |<| [val:bool msg:String]
-            exited(val msg) ^
-        |Hello|
-            -> ("howdy A" 0) $A ^
-        |Goodbye|
-            (false "tootles B") -> $B ^
-        |Both|
-            (true "ciao B") -> ("sup A" 101) $B ^
+            exited(val msg.clone()) ^
+        |Next|
+            (true "bye B") -> ("hi again A" 3) $A ^
 
     -actions-
     entered [msg:String val:i16]

--- a/framec_tests/src/event_params.frm
+++ b/framec_tests/src/event_params.frm
@@ -1,0 +1,39 @@
+#EventParams
+    -interface-
+    Hello
+    Goodbye
+    Both
+    
+    -machine-
+    $A
+        |>| [msg:String val:i16]
+            entered(msg val) ^
+        |<| [val:bool msg:String]
+            exited(val msg) ^
+        |Hello|
+            -> ("hello B" 42) $B ^
+        |Goodbye|
+            (true "goodbye A") -> $B ^
+        |Both|
+            (false "bye A") -> ("hi B" -42) $B ^
+
+    $B
+        |>| [msg:String val:i16]
+            entered(msg val) ^
+        |<| [val:bool msg:String]
+            exited(val msg) ^
+        |Hello|
+            -> ("howdy A" 0) $A ^
+        |Goodbye|
+            (false "tootles B") -> $B ^
+        |Both|
+            (true "ciao B") -> ("sup A" 101) $B ^
+
+    -actions-
+    entered [msg:String val:i16]
+    exited [val:bool msg:String]
+
+    -domain-
+    var enter_log:Log = `vec![]`
+    var exit_log:Log = `vec![]`
+##

--- a/framec_tests/src/event_params.rs
+++ b/framec_tests/src/event_params.rs
@@ -18,32 +18,17 @@ mod tests {
     #[test]
     fn enter() {
         let mut sm = EventParams::new();
-        sm.hello();
-        sm.hello();
-        assert_eq!(sm.enter_log, vec!["hello B 42", "howdy A 0"]);
+        sm.next();
+        assert_eq!(sm.enter_log, vec!["hi A 1", "hi B 2"]);
         assert_eq!(sm.exit_log, Log::new());
     }
 
     #[test]
-    fn exit() {
+    fn enter_and_exit() {
         let mut sm = EventParams::new();
-        sm.goodbye();
-        sm.goodbye();
-        assert_eq!(sm.enter_log, Log::new());
-        assert_eq!(sm.exit_log, vec!["true goodbye A", "false tootles B"]);
-    }
-
-    #[test]
-    fn both() {
-        let mut sm = EventParams::new();
-        sm.hello();
-        sm.both();
-        sm.both();
-        sm.goodbye();
-        assert_eq!(sm.enter_log, vec!["hello B 42", "sup A 101", "hi B -42"]);
-        assert_eq!(
-            sm.exit_log,
-            vec!["true ciao B", "false bye A", "false tootles B"]
-        );
+        sm.next();
+        sm.next();
+        assert_eq!(sm.enter_log, vec!["hi A 1", "hi B 2", "hi again A 3"]);
+        assert_eq!(sm.exit_log, vec!["true bye B"]);
     }
 }

--- a/framec_tests/src/event_params.rs
+++ b/framec_tests/src/event_params.rs
@@ -1,0 +1,49 @@
+type Log = Vec<String>;
+include!(concat!(env!("OUT_DIR"), "/", "event_params.rs"));
+
+impl EventParams {
+    pub fn entered(&mut self, msg: String, val: i16) {
+        self.enter_log.push(format!("{} {}", msg, val));
+    }
+    pub fn exited(&mut self, val: bool, msg: String) {
+        self.exit_log.push(format!("{} {}", val, msg));
+    }
+    pub fn transition_hook(&mut self, _current: EventParamsState, _next: EventParamsState) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enter() {
+        let mut sm = EventParams::new();
+        sm.hello();
+        sm.hello();
+        assert_eq!(sm.enter_log, vec!["hello B 42", "howdy A 0"]);
+        assert_eq!(sm.exit_log, Log::new());
+    }
+
+    #[test]
+    fn exit() {
+        let mut sm = EventParams::new();
+        sm.goodbye();
+        sm.goodbye();
+        assert_eq!(sm.enter_log, Log::new());
+        assert_eq!(sm.exit_log, vec!["true goodbye A", "false tootles B"]);
+    }
+
+    #[test]
+    fn both() {
+        let mut sm = EventParams::new();
+        sm.hello();
+        sm.both();
+        sm.both();
+        sm.goodbye();
+        assert_eq!(sm.enter_log, vec!["hello B 42", "sup A 101", "hi B -42"]);
+        assert_eq!(
+            sm.exit_log,
+            vec!["true ciao B", "false bye A", "false tootles B"]
+        );
+    }
+}

--- a/framec_tests/src/hierarchical.rs
+++ b/framec_tests/src/hierarchical.rs
@@ -21,7 +21,7 @@ mod tests {
     fn hierarchical_entry_calls() {
         let mut sm = Hierarchical::new();
         sm.entry_log.clear();
-        sm.A();
+        sm.a();
         assert_eq!(sm.entry_log, vec!["S", "S0"]);
     }
 
@@ -30,21 +30,21 @@ mod tests {
     #[ignore]
     fn hierarchical_exit_calls() {
         let mut sm = Hierarchical::new();
-        sm.A();
+        sm.a();
         sm.exit_log.clear();
-        sm.C();
+        sm.c();
         assert_eq!(sm.exit_log, vec!["S", "S0"]);
     }
 
     #[test]
     fn hierarchical_current_state() {
         let mut sm = Hierarchical::new();
-        assert_eq!(sm.get_current_state_enum(), HierarchicalState::I);
-        sm.A();
-        assert_eq!(sm.get_current_state_enum(), HierarchicalState::S0);
-        sm.B();
-        assert_eq!(sm.get_current_state_enum(), HierarchicalState::S1);
-        sm.C();
-        assert_eq!(sm.get_current_state_enum(), HierarchicalState::I);
+        assert_eq!(sm.state, HierarchicalState::I);
+        sm.a();
+        assert_eq!(sm.state, HierarchicalState::S0);
+        sm.b();
+        assert_eq!(sm.state, HierarchicalState::S1);
+        sm.c();
+        assert_eq!(sm.state, HierarchicalState::I);
     }
 }

--- a/framec_tests/src/hierarchical_guard.rs
+++ b/framec_tests/src/hierarchical_guard.rs
@@ -23,9 +23,9 @@ mod tests {
     #[test]
     fn hierarchical_child_transition_handler_with_guard() {
         let mut sm = HierarchicalGuard::new();
-        sm.A();
-        sm.B(true);
-        assert_eq!(sm.get_current_state_enum(), HierarchicalGuardState::S1);
+        sm.a();
+        sm.b(true);
+        assert_eq!(sm.state, HierarchicalGuardState::S1);
     }
 
     // Revisit: parent handler for event isn't getting called if child has handler
@@ -34,8 +34,8 @@ mod tests {
     #[ignore]
     fn hierarchical_parent_transition_handler_with_guard() {
         let mut sm = HierarchicalGuard::new();
-        sm.A();
-        sm.B(false);
-        assert_eq!(sm.get_current_state_enum(), HierarchicalGuardState::I);
+        sm.a();
+        sm.b(false);
+        assert_eq!(sm.state, HierarchicalGuardState::I);
     }
 }

--- a/framec_tests/src/lib.rs
+++ b/framec_tests/src/lib.rs
@@ -2,3 +2,4 @@ mod basic;
 mod empty;
 mod hierarchical;
 mod hierarchical_guard;
+mod state_params;

--- a/framec_tests/src/lib.rs
+++ b/framec_tests/src/lib.rs
@@ -1,5 +1,7 @@
 mod basic;
 mod empty;
+// mod event_params;
 mod hierarchical;
 mod hierarchical_guard;
 mod state_params;
+// mod state_vars;

--- a/framec_tests/src/lib.rs
+++ b/framec_tests/src/lib.rs
@@ -3,6 +3,7 @@ mod empty;
 mod event_handler;
 mod hierarchical;
 mod hierarchical_guard;
+mod state_context;
 mod state_params;
 mod state_vars;
 mod transition_params;

--- a/framec_tests/src/lib.rs
+++ b/framec_tests/src/lib.rs
@@ -1,7 +1,8 @@
 mod basic;
 mod empty;
-mod event_params;
+mod event_handler;
 mod hierarchical;
 mod hierarchical_guard;
 mod state_params;
 mod state_vars;
+mod transition_params;

--- a/framec_tests/src/lib.rs
+++ b/framec_tests/src/lib.rs
@@ -1,7 +1,7 @@
 mod basic;
 mod empty;
-// mod event_params;
+mod event_params;
 mod hierarchical;
 mod hierarchical_guard;
 mod state_params;
-// mod state_vars;
+mod state_vars;

--- a/framec_tests/src/lib.rs
+++ b/framec_tests/src/lib.rs
@@ -6,3 +6,4 @@ mod hierarchical_guard;
 mod state_params;
 mod state_vars;
 mod transition_params;
+mod var_scope;

--- a/framec_tests/src/lib.rs
+++ b/framec_tests/src/lib.rs
@@ -1,3 +1,4 @@
 mod basic;
+mod empty;
 mod hierarchical;
 mod hierarchical_guard;

--- a/framec_tests/src/state_context.frm
+++ b/framec_tests/src/state_context.frm
@@ -1,0 +1,57 @@
+#StateContextSm
+    -interface-
+    Inc : i32
+    Next [arg:i32]
+
+    -machine-
+    $Init
+        |>| -> (3 5) $Foo ^
+    
+    $Foo
+        var x:i32 = 0
+        
+        |>| [a:i32 b:i32]
+            log("a" a)
+            log("b" b)
+            x = a * b
+            log("x" x)
+            ^
+        
+        |<| [c:i32]
+            log("c" c)
+            x = x + c
+            log("x" x)
+            ^
+        
+        |Inc|
+            x = x + 1
+            log("x" x)
+            ^(x)
+        
+        |Next| [arg:i32]
+            var tmp = arg * 10  --- FIXME: Swapping this to 10 * arg causes a parse error!
+            (10) -> (tmp) $Bar(x)
+            ^
+
+    $Bar [y:i32]
+        
+        var z:i32 = 0
+        
+        |>| [a:i32]
+            log("a" a)
+            log("y" y)
+            z = a + y
+            log("z" z)
+            ^
+        
+        |Inc|
+            z = z + 1
+            log("z" z)
+            ^(z)
+    
+    -actions-
+    log [name:String val:i32]
+
+    -domain-
+    var tape:Log = `vec![]`
+##

--- a/framec_tests/src/state_context.rs
+++ b/framec_tests/src/state_context.rs
@@ -1,0 +1,42 @@
+//! Tests the interaction of several features (state variables, state
+//! parameters, event parameters, event variables, return values) that are
+//! implemented via state contexts.
+
+type Log = Vec<String>;
+include!(concat!(env!("OUT_DIR"), "/", "state_context.rs"));
+
+impl StateContextSm {
+    pub fn log(&mut self, name: String, val: i32) {
+        self.tape.push(format!("{}={}", name, val));
+    }
+
+    pub fn transition_hook(&mut self, _current: StateContextSmState, _next: StateContextSmState) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interaction() {
+        let mut sm = StateContextSm::new();
+        assert_eq!(sm.tape, vec!["a=3", "b=5", "x=15"]);
+        sm.tape.clear();
+
+        sm.inc();
+        let r = sm.inc();
+        assert_eq!(r, 17);
+        assert_eq!(sm.tape, vec!["x=16", "x=17"]);
+        sm.tape.clear();
+
+        sm.next(3);
+        assert_eq!(sm.tape, vec!["c=10", "x=27", "a=30", "y=17", "z=47"]);
+        sm.tape.clear();
+
+        sm.inc();
+        sm.inc();
+        let r = sm.inc();
+        assert_eq!(r, 50);
+        assert_eq!(sm.tape, vec!["z=48", "z=49", "z=50"]);
+    }
+}

--- a/framec_tests/src/state_params.frm
+++ b/framec_tests/src/state_params.frm
@@ -1,0 +1,29 @@
+#StateParams
+    -interface-
+    Next
+    Prev
+    Log
+    
+    -machine-
+    $Init
+        |Next| -> $Split(1) ^
+
+    $Split [val:u32]
+        |Next| -> $Merge(val val+1) ^
+        |Prev| -> $Merge(val+1 val) ^
+        |Log| got_param("val" val) ^
+
+    $Merge [left:u32 right:u32]
+        |Next| -> $Split(left+right) ^
+        |Prev| -> $Split(left*right) ^
+        |Log|
+            got_param("left" left)
+            got_param("right" right)
+            ^
+
+    -actions-
+    got_param [name:&String val:u32]
+
+    -domain-
+    var param_log: Log = `vec![]`
+##

--- a/framec_tests/src/state_params.rs
+++ b/framec_tests/src/state_params.rs
@@ -1,0 +1,45 @@
+type Log = Vec<String>;
+include!(concat!(env!("OUT_DIR"), "/", "state_params.rs"));
+
+impl StateParams {
+    pub fn got_param(&mut self, name: String, val: u32) {
+        self.param_log.push(format!("{}={}", name, val));
+    }
+    pub fn transition_hook(&mut self, _current: StateParamsState, _next: StateParamsState) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_parameter() {
+        let mut sm = StateParams::new();
+        sm.next();
+        sm.log();
+        assert_eq!(sm.param_log, vec!["val=1"]);
+    }
+
+    #[test]
+    fn multiple_parameters() {
+        let mut sm = StateParams::new();
+        sm.next();
+        sm.next();
+        sm.log();
+        assert_eq!(sm.param_log, vec!["left=1", "right=2"]);
+    }
+
+    #[test]
+    fn several_passes() {
+        let mut sm = StateParams::new();
+        sm.next(); // val=1
+        sm.next(); // left=1, right=2
+        sm.next(); // val=3
+        sm.log();
+        sm.prev(); // left=4, right=3
+        sm.log();
+        sm.prev(); // val=12
+        sm.log();
+        assert_eq!(sm.param_log, vec!["val=3", "left=4", "right=3", "val=12"]);
+    }
+}

--- a/framec_tests/src/state_vars.frm
+++ b/framec_tests/src/state_vars.frm
@@ -1,0 +1,24 @@
+#StateVars
+    -interface-
+    X
+    Y
+    Z
+    
+    -machine-
+    $A
+        var x:u32 = 0
+        |X| x = x + 1 ^
+        |Y| -> $B ^
+        |Z| -> $B ^
+
+    $B
+        var y:u32 = 10
+        var z:u32 = 100
+        |X| -> $A ^
+        |Y| y = y + 1 ^
+        |Z| z = z + 1 ^
+
+    -actions-
+
+    -domain-
+##

--- a/framec_tests/src/state_vars.frm
+++ b/framec_tests/src/state_vars.frm
@@ -5,6 +5,9 @@
     Z
     
     -machine-
+    $Init
+        |>| -> $A ^
+    
     $A
         var x:u32 = 0
         |X| x = x + 1 ^

--- a/framec_tests/src/state_vars.rs
+++ b/framec_tests/src/state_vars.rs
@@ -1,0 +1,54 @@
+include!(concat!(env!("OUT_DIR"), "/", "state_vars.rs"));
+
+impl StateVars {
+    pub fn transition_hook(&mut self, _current: StateVarsState, _next: StateVarsState) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_variable() {
+        let sm = StateVars::new();
+        assert_eq!(sm.state, StateVarsState::A);
+        // check x = 0
+        sm.x(); // increment x
+        sm.x(); // increment x
+        // check x = 2
+    }
+
+    #[test]
+    fn multiple_variables() {
+        let sm = StateVars::new();
+        sm.y(); // transition to B
+        assert_eq!(sm.state, StateVarsState::B);
+        // check y = 10
+        // check z = 100
+        sm.y(); // increment y
+        sm.y(); // increment y
+        sm.z(); // increment z
+        sm.y(); // increment y
+        // check y = 13
+        // check z = 101
+    }
+    
+    #[test]
+    fn variables_are_reset() {
+        let sm = StateVars::new();
+        sm.x(); // increment x
+        sm.x(); // increment x
+        // check x = 2
+        sm.z(); // transition to B
+        sm.z(); // increment z
+        sm.y(); // increment y
+        sm.z(); // increment z
+        // check y = 11
+        // check z = 102
+        sm.x(); // transition to A
+        // check x = 0
+        sm.y(); // transition to B
+        // check y = 10
+        // check z = 100
+    }
+}

--- a/framec_tests/src/state_vars.rs
+++ b/framec_tests/src/state_vars.rs
@@ -10,45 +10,45 @@ mod tests {
 
     #[test]
     fn single_variable() {
-        let sm = StateVars::new();
+        let mut sm = StateVars::new();
         assert_eq!(sm.state, StateVarsState::A);
-        // check x = 0
+        assert_eq!(sm.state_context.a_context().borrow().state_vars.x, 0);
         sm.x(); // increment x
         sm.x(); // increment x
-        // check x = 2
+        assert_eq!(sm.state_context.a_context().borrow().state_vars.x, 2);
     }
 
     #[test]
     fn multiple_variables() {
-        let sm = StateVars::new();
+        let mut sm = StateVars::new();
         sm.y(); // transition to B
         assert_eq!(sm.state, StateVarsState::B);
-        // check y = 10
-        // check z = 100
+        assert_eq!(sm.state_context.b_context().borrow().state_vars.y, 10);
+        assert_eq!(sm.state_context.b_context().borrow().state_vars.z, 100);
         sm.y(); // increment y
         sm.y(); // increment y
         sm.z(); // increment z
         sm.y(); // increment y
-        // check y = 13
-        // check z = 101
+        assert_eq!(sm.state_context.b_context().borrow().state_vars.y, 13);
+        assert_eq!(sm.state_context.b_context().borrow().state_vars.z, 101);
     }
-    
+
     #[test]
     fn variables_are_reset() {
-        let sm = StateVars::new();
+        let mut sm = StateVars::new();
         sm.x(); // increment x
         sm.x(); // increment x
-        // check x = 2
+        assert_eq!(sm.state_context.a_context().borrow().state_vars.x, 2);
         sm.z(); // transition to B
         sm.z(); // increment z
         sm.y(); // increment y
         sm.z(); // increment z
-        // check y = 11
-        // check z = 102
+        assert_eq!(sm.state_context.b_context().borrow().state_vars.y, 11);
+        assert_eq!(sm.state_context.b_context().borrow().state_vars.z, 102);
         sm.x(); // transition to A
-        // check x = 0
+        assert_eq!(sm.state_context.a_context().borrow().state_vars.x, 0);
         sm.y(); // transition to B
-        // check y = 10
-        // check z = 100
+        assert_eq!(sm.state_context.b_context().borrow().state_vars.y, 10);
+        assert_eq!(sm.state_context.b_context().borrow().state_vars.z, 100);
     }
 }

--- a/framec_tests/src/transition_params.frm
+++ b/framec_tests/src/transition_params.frm
@@ -1,4 +1,4 @@
-#EventParams
+#TransitParams
     -interface-
     Next
     

--- a/framec_tests/src/transition_params.rs
+++ b/framec_tests/src/transition_params.rs
@@ -1,3 +1,6 @@
+//! Test transition parameters, i.e. arguments passed to the enter/exit
+//! handlers during a transition.
+
 type Log = Vec<String>;
 include!(concat!(env!("OUT_DIR"), "/", "transition_params.rs"));
 

--- a/framec_tests/src/transition_params.rs
+++ b/framec_tests/src/transition_params.rs
@@ -1,14 +1,14 @@
 type Log = Vec<String>;
-include!(concat!(env!("OUT_DIR"), "/", "event_params.rs"));
+include!(concat!(env!("OUT_DIR"), "/", "transition_params.rs"));
 
-impl EventParams {
+impl TransitParams {
     pub fn entered(&mut self, msg: String, val: i16) {
         self.enter_log.push(format!("{} {}", msg, val));
     }
     pub fn exited(&mut self, val: bool, msg: String) {
         self.exit_log.push(format!("{} {}", val, msg));
     }
-    pub fn transition_hook(&mut self, _current: EventParamsState, _next: EventParamsState) {}
+    pub fn transition_hook(&mut self, _current: TransitParamsState, _next: TransitParamsState) {}
 }
 
 #[cfg(test)]
@@ -17,7 +17,7 @@ mod tests {
 
     #[test]
     fn enter() {
-        let mut sm = EventParams::new();
+        let mut sm = TransitParams::new();
         sm.next();
         assert_eq!(sm.enter_log, vec!["hi A 1", "hi B 2"]);
         assert_eq!(sm.exit_log, Log::new());
@@ -25,7 +25,7 @@ mod tests {
 
     #[test]
     fn enter_and_exit() {
-        let mut sm = EventParams::new();
+        let mut sm = TransitParams::new();
         sm.next();
         sm.next();
         assert_eq!(sm.enter_log, vec!["hi A 1", "hi B 2", "hi again A 3"]);

--- a/framec_tests/src/var_scope.frm
+++ b/framec_tests/src/var_scope.frm
@@ -1,0 +1,241 @@
+#VarScope
+    -interface-
+    to_nn
+    to_ny
+    to_yn
+    to_yy
+    nn [d:String]
+    ny [d:String]
+    yn [d:String x:String]
+    yy [d:String x:String]
+    sigils [x:String]
+
+    -machine-
+    $Init
+        |to_nn| -> $NN ("$NN[b]") ^
+        |to_ny| -> $NY ("$NY[b]") ^
+        |to_yn| -> $YN ("$YN[b]" "$YN[x]") ^
+        |to_yy| -> $YY ("$YY[b]" "$YY[x]") ^
+
+    $NN [b:String]
+        var c:String = "$NN.c"
+
+        |nn| [d:String]
+            var e:String = "|nn|.e"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |ny| [d:String]
+            var e:String = "|ny|.e"
+            var x:String = "|ny|.x"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |yn| [d:String x:String]
+            var e:String = "|yn|.e"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |yy| [d:String x:String]
+            var e:String = "|yy|.e"
+            var x:String = "|yy|.x"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |sigils| [x:String]
+            var x:String = "|sigils|.x"
+            log(#.x.clone())
+            --- log(||[x].clone())
+            --- log(||.x.clone())
+            ^
+
+    $NY [b:String]
+        var c:String = "$NY.c"
+        var x:String = "$NY.x"
+
+        |nn| [d:String]
+            var e:String = "|nn|.e"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |ny| [d:String]
+            var e:String = "|ny|.e"
+            var x:String = "|ny|.x"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |yn| [d:String x:String]
+            var e:String = "|yn|.e"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |yy| [d:String x:String]
+            var e:String = "|yy|.e"
+            var x:String = "|yy|.x"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |sigils| [x:String]
+            var x:String = "|sigils|.x"
+            log(#.x.clone())
+            --- log($.x.clone())
+            --- log(||[x].clone())
+            --- log(||.x.clone())
+            ^
+
+    $YN [b:String x:String]
+        var c:String = "$YN.c"
+
+        |nn| [d:String]
+            var e:String = "|nn|.e"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |ny| [d:String]
+            var e:String = "|ny|.e"
+            var x:String = "|ny|.x"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |yn| [d:String x:String]
+            var e:String = "|yn|.e"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |yy| [d:String x:String]
+            var e:String = "|yy|.e"
+            var x:String = "|yy|.x"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |sigils| [x:String]
+            var x:String = "|sigils|.x"
+            log(#.x.clone())
+            --- log($[x].clone())
+            --- log(||[x].clone())
+            --- log(||.x.clone())
+            ^
+
+    $YY [b:String x:String]
+        var c:String = "$YY.c"
+        var x:String = "$YY.x"
+
+        |nn| [d:String]
+            var e:String = "|nn|.e"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |ny| [d:String]
+            var e:String = "|ny|.e"
+            var x:String = "|ny|.x"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |yn| [d:String x:String]
+            var e:String = "|yn|.e"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |yy| [d:String x:String]
+            var e:String = "|yy|.e"
+            var x:String = "|yy|.x"
+            log(a.clone())
+            log(b.clone())
+            log(c.clone())
+            log(d.clone())
+            log(e.clone())
+            log(x.clone())
+            ^
+
+        |sigils| [x:String]
+            var x:String = "|sigils|.x"
+            log(#.x.clone())
+            --- log($[x].clone())
+            --- log($.x.clone())
+            --- log(||[x].clone())
+            --- log(||.x.clone())
+            ^
+
+    -actions-
+    log [s:String]
+
+    -domain-
+    var a:String = "#.a"
+    var x:String = "#.x"
+    var tape:Log = `vec![]`
+##

--- a/framec_tests/src/var_scope.rs
+++ b/framec_tests/src/var_scope.rs
@@ -1,0 +1,142 @@
+//! There are five different kinds of variables in Frame. Variables lower in
+//! the following list shadow variables higher in the list. Frame uses a
+//! variety of sigils to disambiguate potentially shadowed variables, which
+//! are indicated in parentheses below.
+//!
+//!   * domain variables (`#.v`)
+//!   * state parameters (`$[v]`)
+//!   * state variables (`$.v`)
+//!   * event handler parameters (`||[v]`)
+//!   * event handler variables (`||.v`)
+//!
+//! This module tests that variable shadowing and the disambiguation sigils
+//! work as expected.
+
+type Log = Vec<String>;
+include!(concat!(env!("OUT_DIR"), "/", "var_scope.rs"));
+
+#[allow(dead_code)]
+impl VarScope {
+    pub fn log(&mut self, s: String) {
+        self.tape.push(s);
+    }
+
+    pub fn transition_hook(&mut self, _current: VarScopeState, _next: VarScopeState) {}
+
+    pub fn do_nn(&mut self) {
+        self.nn("|nn|[d]".to_string());
+    }
+
+    pub fn do_ny(&mut self) {
+        self.ny("|ny|[d]".to_string());
+    }
+
+    pub fn do_yn(&mut self) {
+        self.yn("|yn|[d]".to_string(), "|yn|[x]".to_string());
+    }
+
+    pub fn do_yy(&mut self) {
+        self.yy("|yy|[d]".to_string(), "|yy|[x]".to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expected(state: &str, msg: &str, x: &str) -> Log {
+        vec![
+            "#.a".to_string(),
+            format!("${}[b]", state).to_string(),
+            format!("${}.c", state).to_string(),
+            format!("|{}|[d]", msg).to_string(),
+            format!("|{}|.e", msg).to_string(),
+            x.to_string(),
+        ]
+    }
+
+    #[test]
+    fn no_shadowing() {
+        let mut sm = VarScope::new();
+        sm.to_nn();
+        sm.do_nn();
+        assert_eq!(sm.tape, expected("NN", "nn", "#.x"));
+    }
+
+    #[test]
+    fn all_shadowing_scenarios() {
+        let mut sm = VarScope::new();
+        sm.to_nn();
+        sm.do_ny();
+        assert_eq!(sm.tape, expected("NN", "ny", "|ny|.x"));
+        sm.tape.clear();
+        sm.do_yn();
+        assert_eq!(sm.tape, expected("NN", "yn", "|yn|[x]"));
+        sm.tape.clear();
+        sm.do_yy();
+        assert_eq!(sm.tape, expected("NN", "yy", "|yy|.x"));
+
+        sm = VarScope::new();
+        sm.to_ny();
+        sm.do_nn();
+        assert_eq!(sm.tape, expected("NY", "nn", "$NY.x"));
+        sm.tape.clear();
+        sm.do_ny();
+        assert_eq!(sm.tape, expected("NY", "ny", "|ny|.x"));
+        sm.tape.clear();
+        sm.do_yn();
+        assert_eq!(sm.tape, expected("NY", "yn", "|yn|[x]"));
+        sm.tape.clear();
+        sm.do_yy();
+        assert_eq!(sm.tape, expected("NY", "yy", "|yy|.x"));
+
+        sm = VarScope::new();
+        sm.to_yn();
+        sm.do_nn();
+        assert_eq!(sm.tape, expected("YN", "nn", "$YN[x]"));
+        sm.tape.clear();
+        sm.do_ny();
+        assert_eq!(sm.tape, expected("YN", "ny", "|ny|.x"));
+        sm.tape.clear();
+        sm.do_yn();
+        assert_eq!(sm.tape, expected("YN", "yn", "|yn|[x]"));
+        sm.tape.clear();
+        sm.do_yy();
+        assert_eq!(sm.tape, expected("YN", "yy", "|yy|.x"));
+
+        sm = VarScope::new();
+        sm.to_yy();
+        sm.do_nn();
+        assert_eq!(sm.tape, expected("YY", "nn", "$YY.x"));
+        sm.tape.clear();
+        sm.do_ny();
+        assert_eq!(sm.tape, expected("YY", "ny", "|ny|.x"));
+        sm.tape.clear();
+        sm.do_yn();
+        assert_eq!(sm.tape, expected("YY", "yn", "|yn|[x]"));
+        sm.tape.clear();
+        sm.do_yy();
+        assert_eq!(sm.tape, expected("YY", "yy", "|yy|.x"));
+    }
+
+    #[test]
+    #[ignore]
+    fn disambiguation() {
+        let mut sm = VarScope::new();
+        sm.to_nn();
+        sm.sigils("foo".to_string());
+        assert_eq!(sm.tape, vec!["#.x", "foo", "|sigils|.x"]);
+        sm = VarScope::new();
+        sm.to_ny();
+        sm.sigils("foo".to_string());
+        assert_eq!(sm.tape, vec!["#.x", "$NY.x", "foo", "|sigils|.x"]);
+        sm = VarScope::new();
+        sm.to_yn();
+        sm.sigils("foo".to_string());
+        assert_eq!(sm.tape, vec!["#.x", "$YN[x]", "foo", "|sigils|.x"]);
+        sm = VarScope::new();
+        sm.to_yy();
+        sm.sigils("foo".to_string());
+        assert_eq!(sm.tape, vec!["#.x", "$YY[x]", "$YY.x", "foo", "|sigils|.x"]);
+    }
+}


### PR DESCRIPTION
This is a refactoring of the Rust backend to simplify the representation of states.

## Overview

Previously, states were represented as references to the corresponding event handler methods. This meant that introspection features relied on method pointer comparisons. It is unclear from Rust documentation whether these pointers are guaranteed to be stable, so this solution seemed potentially brittle.

Now states are represented by a simple enum value. When a new event is received, a new `handle_event` method is invoked to dispatch to the corresponding event handler (i.e. the old state representations). Besides resolving the concern about method pointer comparisons, this representation simplifies various other aspects of the generated code.

Previously, the state enum value was only generated when the `introspection` feature option was enabled. This feature option has been removed since the state enum must always be generated.


## Other changes

This pull request also makes a few other changes to improve the robustness and quality of the generated Rust code.

 * It adds tests for several features that use state contexts (state variables, state parameters, event parameters). Some of these tests were failing before the refactor. They all pass now.

 * The `lower_case_states` feature option has been replaced by the `follow_rust_naming` feature option, which attempts to more comprehensively follow Rust naming conventions in the generated code (e.g. `snake_case` for methods and variables, `CamelCase` for types and enum cases).


## Known issues

 * I applied the `follow_rust_naming` feature throughout my refactoring, but unaffected parts of the code don't make use of it yet. This feature needs tests and further work to ensure it's applied to all generated names that depend on values from the user's Frame spec. We also need to decide whether to apply this feature to names generated from values in the configuration file. Currently, I do not do this, assuming that provided configuration values override this option.

 * State variables (and likely other features that rely on the state context) do not work with initial states. This is because the process to generate the initial state context is different from the process to generate other state contexts. This was an issue that existed before this refactoring but was not addressed by it. An easy workaround is to define a trivial initial state with an enter event handler that immediately transitions to the "true" initial state.

 * The new state representation is untested with the state history feature. I tried to proactively refactor this but it's likely to contain issues. I also did not test this feature before the refactor, so I'm not sure what the prior status of the feature is.


## Next steps

 * Resolve issues related to hierarchical state machines (see current ignored tests). This is a high priority item for us, so I'll probably try to tackle this first.

 * More tests and resolving issues that arise. In particular, I want to test event variables, the hook method feature, and handler return values.

 * Apply the `follow_rust_naming` feature more extensively and provide corresponding tests.

 * Improve the configuration system. We have some changes in mind that will make the configuration system more robust and easier to use. I'll share these separately rather than veer further from the focus of this pull request. :-) 