### PR TITLE
Tests and bug fixes for boolean tests and conditional continues

### DIFF
--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -3330,7 +3330,7 @@ impl AstVisitor for RustVisitor {
         self.newline();
         for branch_node in &bool_test_node.conditional_branch_nodes {
             if branch_node.is_negated {
-                self.add_code(&format!("{}!", if_or_else_if));
+                self.add_code(&format!("{}!(", if_or_else_if));
             } else {
                 self.add_code(&format!("{}", if_or_else_if));
             }
@@ -3338,7 +3338,7 @@ impl AstVisitor for RustVisitor {
             branch_node.expr_t.accept(self);
 
             if branch_node.is_negated {
-                self.add_code(&format!(""));
+                self.add_code(&format!(")"));
             }
             self.add_code(&format!(" {{"));
             self.indent();

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -253,7 +253,7 @@ pub struct RustVisitor {
     has_states: bool,
     errors: Vec<String>,
     visiting_call_chain_literal_variable: bool,
-    handler_transitioned: bool,
+    this_branch_transitioned: bool,
     generate_exit_args: bool,
     generate_state_context: bool,
     generate_state_stack: bool,
@@ -296,7 +296,7 @@ impl RustVisitor {
             errors: Vec::new(),
             warnings: Vec::new(),
             visiting_call_chain_literal_variable: false,
-            handler_transitioned: false,
+            this_branch_transitioned: false,
             generate_exit_args,
             generate_state_context,
             generate_state_stack,
@@ -1410,6 +1410,25 @@ impl RustVisitor {
         self.newline();
         self.add_code("}");
         self.newline();
+    }
+
+    //* --------------------------------------------------------------------- *//
+
+    /// Generate a return statement within a handler. Call this rather than
+    /// adding a return statement directly to ensure that the control-flow
+    /// state is properly maintained.
+    fn generate_return(&mut self) {
+        self.newline();
+        self.add_code("return;");
+        self.this_branch_transitioned = false;
+    }
+
+    /// Generate a return statement if the current branch contained a
+    /// transition or change-state.
+    fn generate_return_if_transitioned(&mut self) {
+        if self.this_branch_transitioned {
+            self.generate_return();
+        }
     }
 
     //* --------------------------------------------------------------------- *//
@@ -2915,6 +2934,8 @@ impl AstVisitor for RustVisitor {
 
         self.add_code("#[allow(clippy::needless_return)]");
         self.newline();
+        self.add_code("#[allow(unreachable_code)]");
+        self.newline();
         self.add_code("#[allow(unreachable_patterns)]");
         self.newline();
         self.add_code("#[allow(unused_mut)]");
@@ -3058,38 +3079,32 @@ impl AstVisitor for RustVisitor {
         evt_handler_terminator_node: &TerminatorExpr,
     ) -> AstVisitorReturnType {
         match &evt_handler_terminator_node.terminator_type {
-            TerminatorType::Return => match &evt_handler_terminator_node.return_expr_t_opt {
-                Some(expr_t) => {
-                    self.newline();
-                    self.add_code(&format!(
-                        "{}.{} = ",
-                        self.config.frame_event_variable_name,
-                        self.config.frame_event_return_attribute_name
-                    ));
-                    self.add_code(&format!(
-                        "{}::{} {{ return_value: ",
-                        self.config.frame_event_return,
-                        self.format_type_name(&self.current_message)
-                    ));
-                    expr_t.accept(self);
+            TerminatorType::Return => {
+                match &evt_handler_terminator_node.return_expr_t_opt {
+                    Some(expr_t) => {
+                        self.newline();
+                        self.add_code(&format!(
+                            "{}.{} = ",
+                            self.config.frame_event_variable_name,
+                            self.config.frame_event_return_attribute_name
+                        ));
+                        self.add_code(&format!(
+                            "{}::{} {{ return_value: ",
+                            self.config.frame_event_return,
+                            self.format_type_name(&self.current_message)
+                        ));
+                        expr_t.accept(self);
 
-                    self.add_code(" };");
-                    self.newline();
-                    self.add_code("return;");
-                }
-                None => {
-                    self.newline();
-                    self.add_code("return;")
-                }
-            },
+                        self.add_code(" };");
+                    }
+                    None => {}
+                };
+                self.generate_return();
+            }
             TerminatorType::Continue => {
-                if self.handler_transitioned {
-                    self.newline();
-                    self.add_code("return;")
-                }
+                self.generate_return_if_transitioned();
             }
         }
-        self.handler_transitioned = false;
         AstVisitorReturnType::EventHandlerTerminatorNode {}
     }
 
@@ -3243,7 +3258,7 @@ impl AstVisitor for RustVisitor {
                 self.generate_state_stack_pop_transition(transition_statement)
             }
         };
-        self.handler_transitioned = true;
+        self.this_branch_transitioned = true;
 
         AstVisitorReturnType::CallStatementNode {}
     }
@@ -3270,7 +3285,7 @@ impl AstVisitor for RustVisitor {
                 "Fatal error - change state stack pop not implemented."
             )),
         };
-        self.handler_transitioned = true;
+        self.this_branch_transitioned = true;
 
         AstVisitorReturnType::ChangeStateStmtNode {}
     }
@@ -3344,6 +3359,8 @@ impl AstVisitor for RustVisitor {
             self.indent();
 
             branch_node.accept(self);
+
+            self.generate_return_if_transitioned();
 
             self.outdent();
             self.newline();
@@ -3464,22 +3481,25 @@ impl AstVisitor for RustVisitor {
             Some(branch_terminator_expr) => {
                 self.newline();
                 match &branch_terminator_expr.terminator_type {
-                    TerminatorType::Return => match &branch_terminator_expr.return_expr_t_opt {
-                        Some(expr_t) => {
-                            self.add_code(&format!("e._return = "));
-                            expr_t.accept(self);
-                            self.add_code(";");
-                            self.newline();
-                            self.add_code("return;");
-                        }
-                        None => self.add_code("return;"),
-                    },
+                    TerminatorType::Return => {
+                        match &branch_terminator_expr.return_expr_t_opt {
+                            Some(expr_t) => {
+                                self.add_code(&format!("e._return = "));
+                                expr_t.accept(self);
+                                self.add_code(";");
+                            }
+                            None => {}
+                        };
+                        self.generate_return();
+                    }
                     TerminatorType::Continue => {
-                        self.add_code("break;");
+                        self.generate_return_if_transitioned();
                     }
                 }
             }
-            None => {}
+            None => {
+                self.generate_return_if_transitioned();
+            }
         }
 
         AstVisitorReturnType::BoolTestConditionalBranchNode {}
@@ -3506,17 +3526,20 @@ impl AstVisitor for RustVisitor {
                             self.add_code(&format!("e._return = ",));
                             expr_t.accept(self);
                             self.add_code(";");
-                            self.newline();
-                            self.add_code("return;");
+                            self.generate_return();
                         }
-                        None => self.add_code("return;"),
+                        None => {
+                            self.generate_return();
+                        }
                     },
                     TerminatorType::Continue => {
-                        self.add_code("break;");
+                        self.generate_return_if_transitioned();
                     }
                 }
             }
-            None => {}
+            None => {
+                self.generate_return_if_transitioned();
+            }
         }
 
         self.outdent();
@@ -3599,6 +3622,8 @@ impl AstVisitor for RustVisitor {
 
             match_branch_node.accept(self);
 
+            self.generate_return_if_transitioned();
+
             self.outdent();
             self.newline();
             self.add_code(&format!("}}"));
@@ -3626,22 +3651,25 @@ impl AstVisitor for RustVisitor {
             Some(branch_terminator_expr) => {
                 self.newline();
                 match &branch_terminator_expr.terminator_type {
-                    TerminatorType::Return => match &branch_terminator_expr.return_expr_t_opt {
-                        Some(expr_t) => {
-                            self.add_code(&format!("e._return = "));
-                            expr_t.accept(self);
-                            self.add_code(";");
-                            self.newline();
-                            self.add_code("return;");
-                        }
-                        None => self.add_code("return;"),
-                    },
+                    TerminatorType::Return => {
+                        match &branch_terminator_expr.return_expr_t_opt {
+                            Some(expr_t) => {
+                                self.add_code(&format!("e._return = "));
+                                expr_t.accept(self);
+                                self.add_code(";");
+                            }
+                            None => {}
+                        };
+                        self.generate_return();
+                    }
                     TerminatorType::Continue => {
-                        self.add_code("break;");
+                        self.generate_return_if_transitioned();
                     }
                 }
             }
-            None => {}
+            None => {
+                self.generate_return_if_transitioned();
+            }
         }
 
         AstVisitorReturnType::StringMatchTestMatchBranchNode {}
@@ -3663,22 +3691,25 @@ impl AstVisitor for RustVisitor {
             Some(branch_terminator_expr) => {
                 self.newline();
                 match &branch_terminator_expr.terminator_type {
-                    TerminatorType::Return => match &branch_terminator_expr.return_expr_t_opt {
-                        Some(expr_t) => {
-                            self.add_code(&format!("e._return = "));
-                            expr_t.accept(self);
-                            self.add_code(";");
-                            self.newline();
-                            self.add_code("return;");
-                        }
-                        None => self.add_code("return;"),
-                    },
+                    TerminatorType::Return => {
+                        match &branch_terminator_expr.return_expr_t_opt {
+                            Some(expr_t) => {
+                                self.add_code(&format!("e._return = "));
+                                expr_t.accept(self);
+                                self.add_code(";");
+                            }
+                            None => {}
+                        };
+                        self.generate_return();
+                    }
                     TerminatorType::Continue => {
-                        self.add_code("break;");
+                        self.generate_return_if_transitioned();
                     }
                 }
             }
-            None => {}
+            None => {
+                self.generate_return_if_transitioned();
+            }
         }
 
         self.outdent();
@@ -3763,6 +3794,8 @@ impl AstVisitor for RustVisitor {
 
             match_branch_node.accept(self);
 
+            self.generate_return_if_transitioned();
+
             self.outdent();
             self.newline();
             self.add_code(&format!("}}"));
@@ -3791,22 +3824,25 @@ impl AstVisitor for RustVisitor {
             Some(branch_terminator_expr) => {
                 self.newline();
                 match &branch_terminator_expr.terminator_type {
-                    TerminatorType::Return => match &branch_terminator_expr.return_expr_t_opt {
-                        Some(expr_t) => {
-                            self.add_code(&format!("e._return = "));
-                            expr_t.accept(self);
-                            self.add_code(";");
-                            self.newline();
-                            self.add_code("return;");
-                        }
-                        None => self.add_code("return;"),
-                    },
+                    TerminatorType::Return => {
+                        match &branch_terminator_expr.return_expr_t_opt {
+                            Some(expr_t) => {
+                                self.add_code(&format!("e._return = "));
+                                expr_t.accept(self);
+                                self.add_code(";");
+                            }
+                            None => {}
+                        };
+                        self.generate_return();
+                    }
                     TerminatorType::Continue => {
-                        self.add_code("break;");
+                        self.generate_return_if_transitioned();
                     }
                 }
             }
-            None => {}
+            None => {
+                self.generate_return_if_transitioned();
+            }
         }
 
         AstVisitorReturnType::NumberMatchTestMatchBranchNode {}
@@ -3828,22 +3864,25 @@ impl AstVisitor for RustVisitor {
             Some(branch_terminator_expr) => {
                 self.newline();
                 match &branch_terminator_expr.terminator_type {
-                    TerminatorType::Return => match &branch_terminator_expr.return_expr_t_opt {
-                        Some(expr_t) => {
-                            self.add_code(&format!("e._return = "));
-                            expr_t.accept(self);
-                            self.add_code(";");
-                            self.newline();
-                            self.add_code("return;");
-                        }
-                        None => self.add_code("return;"),
-                    },
+                    TerminatorType::Return => {
+                        match &branch_terminator_expr.return_expr_t_opt {
+                            Some(expr_t) => {
+                                self.add_code(&format!("e._return = "));
+                                expr_t.accept(self);
+                                self.add_code(";");
+                            }
+                            None => {}
+                        };
+                        self.generate_return();
+                    }
                     TerminatorType::Continue => {
-                        self.add_code("break;");
+                        self.generate_return_if_transitioned();
                     }
                 }
             }
-            None => {}
+            None => {
+                self.generate_return_if_transitioned();
+            }
         }
 
         self.outdent();

--- a/framec_tests/src/branch.frm
+++ b/framec_tests/src/branch.frm
@@ -8,7 +8,7 @@
     F
     OnBool [b:bool]
     OnInt [i:i16]
-    
+
     -machine-
     $I
         |A| -> $SimpleIf ^
@@ -17,13 +17,13 @@
         |D| -> $NestedIf ^
         |E| -> $GuardedTransition ^
         |F| -> $NestedGuardedTransition ^
-    
+
     $SimpleIf
         |OnBool| [b:bool]
             b ? log("then 1") : ::
-            b ? : log("else 1") :: 
+            b ? : log("else 1") ::
             b ? log("then 2") : log("else 2") :: b ? -> $F1 : -> $F2 :: ^
-        
+
         |OnInt| [i:i16]
             i > 5 ? log("> 5") : log("<= 5") ::
             i < 10 ? log("< 10") : log(">= 10") ::
@@ -35,15 +35,15 @@
                 -> $F2
             ::
             ^
-    
+
     $NegatedIf
         |OnBool| [b:bool]
             b ?! log("then 1") : ::
-            b ?! : log("else 1") :: 
-            b ?! log("then 2") : log("else 2") :: 
+            b ?! : log("else 1") ::
+            b ?! log("then 2") : log("else 2") ::
             b ?! -> $F1 : -> $F2 ::
             ^
-        
+
         |OnInt| [i:i16]
             i >= 5 ?! log("< 5") : log(">= 5") ::
             i <= 10 ?! log("> 10") : log("<= 10") ::
@@ -100,7 +100,7 @@
                 ::
             ::
             ^
-              
+
       $GuardedTransition
           |OnInt| [i:i16]
               i > 100 ?
@@ -115,7 +115,7 @@
               log("-> $F3")
               -> $F3
               ^
-      
+
       $NestedGuardedTransition
           |OnInt| [i:i16]
               i > 10 ?
@@ -124,7 +124,7 @@
                       -> $F1
                   : ::
                   i > 50 ?
-                  : 
+                  :
                       log("-> $F2")
                       -> $F2
                   ::
@@ -136,7 +136,7 @@
     $F1
     $F2
     $F3
-    
+
     -actions-
     log[msg:String]
 

--- a/framec_tests/src/branch.frm
+++ b/framec_tests/src/branch.frm
@@ -5,6 +5,7 @@
     C
     D
     E
+    F
     OnBool [b:bool]
     OnInt [i:i16]
     
@@ -14,7 +15,8 @@
         |B| -> $NegatedIf ^
         |C| -> $Precedence ^
         |D| -> $NestedIf ^
-        |E| -> $TransitReturns ^
+        |E| -> $GuardedTransition ^
+        |F| -> $NestedGuardedTransition ^
     
     $SimpleIf
         |OnBool| [b:bool]
@@ -99,7 +101,7 @@
             ::
             ^
               
-      $TransitReturns
+      $GuardedTransition
           |OnInt| [i:i16]
               i > 100 ?
                   log("-> $F1")
@@ -110,6 +112,23 @@
                   log("-> $F2")
                   -> $F2
               ::
+              log("-> $F3")
+              -> $F3
+              ^
+      
+      $NestedGuardedTransition
+          |OnInt| [i:i16]
+              i > 10 ?
+                  i > 100 ?
+                      log("-> $F1")
+                      -> $F1
+                  : ::
+                  i > 50 ?
+                  : 
+                      log("-> $F2")
+                      -> $F2
+                  ::
+              : ::
               log("-> $F3")
               -> $F3
               ^

--- a/framec_tests/src/branch.frm
+++ b/framec_tests/src/branch.frm
@@ -1,0 +1,126 @@
+#Branch
+    -interface-
+    A
+    B
+    C
+    D
+    E
+    OnBool [b:bool]
+    OnInt [i:i16]
+    
+    -machine-
+    $I
+        |A| -> $SimpleIf ^
+        |B| -> $NegatedIf ^
+        |C| -> $Precedence ^
+        |D| -> $NestedIf ^
+        |E| -> $TransitReturns ^
+    
+    $SimpleIf
+        |OnBool| [b:bool]
+            b ? log("then 1") : ::
+            b ? : log("else 1") :: 
+            b ? log("then 2") : log("else 2") :: b ? -> $F1 : -> $F2 :: ^
+        
+        |OnInt| [i:i16]
+            i > 5 ? log("> 5") : log("<= 5") ::
+            i < 10 ? log("< 10") : log(">= 10") ::
+            i == 7 ?
+                log("== 7")
+                -> $F1
+            :
+                log("!= 7")
+                -> $F2
+            ::
+            ^
+    
+    $NegatedIf
+        |OnBool| [b:bool]
+            b ?! log("then 1") : ::
+            b ?! : log("else 1") :: 
+            b ?! log("then 2") : log("else 2") :: 
+            b ?! -> $F1 : -> $F2 ::
+            ^
+        
+        |OnInt| [i:i16]
+            i >= 5 ?! log("< 5") : log(">= 5") ::
+            i <= 10 ?! log("> 10") : log("<= 10") ::
+            i != 7 ?!
+                log("== 7")
+                -> $F1
+            :
+                log("!= 7")
+                -> $F2
+            ::
+            ^
+
+    $Precedence
+        |OnInt| [i:i16]
+            -i >= 0 && -i <= 5 ?
+                log("then 1")
+            :
+                log("else 1")
+            ::
+            !(i >= -5 && i <= 5) && (i >= -10 && i <= 10) ?
+                log("then 2")
+            :
+                log("else 2")
+            ::
+            i >= 0 && i <= 5 || i >= 10 && i <= 20 ?
+                log("then 3")
+            :
+                log("else 3")
+            ::
+            (i < 0 || i > 10) && i+5 < 20 ?!
+                log("then 4")
+            :
+                log("else 4")
+            ::
+            ^
+
+    $NestedIf
+        |OnInt| [i:i16]
+            i > 0 ?
+                log("> 0")
+                i < 100 ?
+                    log("< 100")
+                    -> $F1
+                :
+                    log(">= 100")
+                ::
+            :
+                log("<= 0")
+                i > -10 ?
+                    log("> -10")
+                :
+                    log("<= -10")
+                    -> $F2
+                ::
+            ::
+            ^
+              
+      $TransitReturns
+          |OnInt| [i:i16]
+              i > 100 ?
+                  log("-> $F1")
+                  -> $F1
+              : ::
+              i > 10 ?!
+              :
+                  log("-> $F2")
+                  -> $F2
+              ::
+              log("-> $F3")
+              -> $F3
+              ^
+
+    $F1
+    $F2
+    $F3
+    
+    -actions-
+    log[msg:String]
+
+    -domain-
+    var tape:Log = `vec![]`
+##

--- a/framec_tests/src/branch.rs
+++ b/framec_tests/src/branch.rs
@@ -132,7 +132,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     /// Test that a transition within a conditional expression returns from
     /// the handler early. That is, only the first executed transition applies.
     fn transition_returns_early() {

--- a/framec_tests/src/branch.rs
+++ b/framec_tests/src/branch.rs
@@ -132,9 +132,9 @@ mod tests {
     }
 
     #[test]
-    /// Test that a transition within a conditional expression returns from
-    /// the handler early. That is, only the first executed transition applies.
-    fn transition_returns_early() {
+    /// Test that a transition guarded by a conditional expression triggers an
+    /// early return from the handler.
+    fn guarded_transition() {
         let mut sm = Branch::new();
         sm.e();
         sm.on_int(5);
@@ -147,6 +147,33 @@ mod tests {
         assert_eq!(sm.tape, vec!["-> $F2"]);
         sm = Branch::new();
         sm.e();
+        sm.on_int(115);
+        assert_eq!(sm.state, BranchState::F1);
+        assert_eq!(sm.tape, vec!["-> $F1"]);
+    }
+
+    #[test]
+    /// Test that a transition guarded by a nested conditional expression
+    /// triggers an early return from the handler, but this return doesn't
+    /// apply to non-transitioned branches.
+    fn nested_guarded_transition() {
+        let mut sm = Branch::new();
+        sm.f();
+        sm.on_int(5);
+        assert_eq!(sm.state, BranchState::F3);
+        assert_eq!(sm.tape, vec!["-> $F3"]);
+        sm = Branch::new();
+        sm.f();
+        sm.on_int(15);
+        assert_eq!(sm.state, BranchState::F2);
+        assert_eq!(sm.tape, vec!["-> $F2"]);
+        sm = Branch::new();
+        sm.f();
+        sm.on_int(65);
+        assert_eq!(sm.state, BranchState::F3);
+        assert_eq!(sm.tape, vec!["-> $F3"]);
+        sm = Branch::new();
+        sm.f();
         sm.on_int(115);
         assert_eq!(sm.state, BranchState::F1);
         assert_eq!(sm.tape, vec!["-> $F1"]);

--- a/framec_tests/src/branch.rs
+++ b/framec_tests/src/branch.rs
@@ -1,0 +1,155 @@
+//! Test conditional expressions and the Boolean branching construct.
+
+type Log = Vec<String>;
+include!(concat!(env!("OUT_DIR"), "/", "branch.rs"));
+
+impl Branch {
+    pub fn log(&mut self, msg: String) {
+        self.tape.push(msg);
+    }
+    pub fn transition_hook(&mut self, _current: BranchState, _next: BranchState) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_if_bool() {
+        let mut sm = Branch::new();
+        sm.a();
+        sm.on_bool(true);
+        assert_eq!(sm.state, BranchState::F1);
+        assert_eq!(sm.tape, vec!["then 1", "then 2"]);
+        sm = Branch::new();
+        sm.a();
+        sm.on_bool(false);
+        assert_eq!(sm.state, BranchState::F2);
+        assert_eq!(sm.tape, vec!["else 1", "else 2"]);
+    }
+
+    #[test]
+    fn simple_if_int() {
+        let mut sm = Branch::new();
+        sm.a();
+        sm.on_int(7);
+        assert_eq!(sm.state, BranchState::F1);
+        assert_eq!(sm.tape, vec!["> 5", "< 10", "== 7"]);
+        sm = Branch::new();
+        sm.a();
+        sm.on_int(-3);
+        assert_eq!(sm.state, BranchState::F2);
+        assert_eq!(sm.tape, vec!["<= 5", "< 10", "!= 7"]);
+        sm = Branch::new();
+        sm.a();
+        sm.on_int(12);
+        assert_eq!(sm.state, BranchState::F2);
+        assert_eq!(sm.tape, vec!["> 5", ">= 10", "!= 7"]);
+    }
+
+    #[test]
+    fn negated_if_bool() {
+        let mut sm = Branch::new();
+        sm.b();
+        sm.on_bool(true);
+        assert_eq!(sm.state, BranchState::F2);
+        assert_eq!(sm.tape, vec!["else 1", "else 2"]);
+        sm = Branch::new();
+        sm.b();
+        sm.on_bool(false);
+        assert_eq!(sm.state, BranchState::F1);
+        assert_eq!(sm.tape, vec!["then 1", "then 2"]);
+    }
+
+    #[test]
+    fn negated_if_int() {
+        let mut sm = Branch::new();
+        sm.b();
+        sm.on_int(7);
+        assert_eq!(sm.state, BranchState::F1);
+        assert_eq!(sm.tape, vec![">= 5", "<= 10", "== 7"]);
+        sm = Branch::new();
+        sm.b();
+        sm.on_int(5);
+        assert_eq!(sm.state, BranchState::F2);
+        assert_eq!(sm.tape, vec![">= 5", "<= 10", "!= 7"]);
+        sm = Branch::new();
+        sm.b();
+        sm.on_int(10);
+        assert_eq!(sm.state, BranchState::F2);
+        assert_eq!(sm.tape, vec![">= 5", "<= 10", "!= 7"]);
+        sm = Branch::new();
+        sm.b();
+        sm.on_int(0);
+        assert_eq!(sm.state, BranchState::F2);
+        assert_eq!(sm.tape, vec!["< 5", "<= 10", "!= 7"]);
+        sm = Branch::new();
+        sm.b();
+        sm.on_int(100);
+        assert_eq!(sm.state, BranchState::F2);
+        assert_eq!(sm.tape, vec![">= 5", "> 10", "!= 7"]);
+    }
+
+    #[test]
+    fn operator_precedence() {
+        let mut sm = Branch::new();
+        sm.c();
+        sm.on_int(0);
+        assert_eq!(sm.tape, vec!["then 1", "else 2", "then 3", "then 4"]);
+        sm.tape.clear();
+        sm.on_int(7);
+        assert_eq!(sm.tape, vec!["else 1", "then 2", "else 3", "then 4"]);
+        sm.tape.clear();
+        sm.on_int(-3);
+        assert_eq!(sm.tape, vec!["then 1", "else 2", "else 3", "else 4"]);
+        sm.tape.clear();
+        sm.on_int(12);
+        assert_eq!(sm.tape, vec!["else 1", "else 2", "then 3", "else 4"]);
+    }
+
+    #[test]
+    fn nested_if() {
+        let mut sm = Branch::new();
+        sm.d();
+        sm.on_int(50);
+        assert_eq!(sm.state, BranchState::F1);
+        assert_eq!(sm.tape, vec!["> 0", "< 100"]);
+        sm = Branch::new();
+        sm.d();
+        sm.on_int(200);
+        assert_eq!(sm.state, BranchState::NestedIf);
+        assert_eq!(sm.tape, vec!["> 0", ">= 100"]);
+        sm = Branch::new();
+        sm.d();
+        sm.on_int(-5);
+        assert_eq!(sm.state, BranchState::NestedIf);
+        assert_eq!(sm.tape, vec!["<= 0", "> -10"]);
+        sm = Branch::new();
+        sm.d();
+        sm.on_int(-10);
+        assert_eq!(sm.state, BranchState::F2);
+        assert_eq!(sm.tape, vec!["<= 0", "<= -10"]);
+    }
+
+    #[test]
+    #[ignore]
+    /// Test that a transition within a conditional expression returns from
+    /// the handler early. That is, only the first executed transition applies.
+    fn transition_returns_early() {
+        let mut sm = Branch::new();
+        sm.e();
+        sm.on_int(5);
+        assert_eq!(sm.state, BranchState::F3);
+        assert_eq!(sm.tape, vec!["-> $F3"]);
+        sm = Branch::new();
+        sm.e();
+        sm.on_int(15);
+        assert_eq!(sm.state, BranchState::F2);
+        assert_eq!(sm.tape, vec!["-> $F2"]);
+        sm = Branch::new();
+        sm.e();
+        sm.on_int(115);
+        assert_eq!(sm.state, BranchState::F1);
+        assert_eq!(sm.tape, vec!["-> $F1"]);
+    }
+}

--- a/framec_tests/src/event_handler.frm
+++ b/framec_tests/src/event_handler.frm
@@ -10,35 +10,35 @@
     $S1
         |LogIt| [x:i32]
             log("x" x) ^
-        
+
         |LogAdd| [a:i32 b:i32]
             log("a" a)
             log("b" b)
             log("a+b" a+b) ^
-        
+
         |LogReturn| [a:i32 b:i32]
             log("a" a)
             log("b" b)
             var r = a + b
             log("r" r)
             -> ^(r)
-        
+
         |PassAdd| [a:i32 b:i32]
             -> $S2(a+b) ^
-        
+
         |PassReturn| [a:i32 b:i32]
             var r = a + b
             log("r" r)
             -> $S2(r) ^(r)
 
     $S2 [p:i32]
-        
+
         |>|
             log("p" p) ^
 
     -actions-
     log [val:i32]
-    
+
     -domain-
     var tape:Log = `vec![]`
 ##

--- a/framec_tests/src/hierarchical.frm
+++ b/framec_tests/src/hierarchical.frm
@@ -5,7 +5,7 @@
     C
     -machine-
     $I  |>| -> $S ^
-    
+
     $S
         |>| enter("S") ^
         |<| exit("S") ^
@@ -13,7 +13,7 @@
             -> $S0 ^
         |B| log("S.B")
             -> $S1 ^
-    
+
     $S0 => $S
         |>| enter("S0") :>
         |<| exit("S0") :>

--- a/framec_tests/src/hierarchical_guard.frm
+++ b/framec_tests/src/hierarchical_guard.frm
@@ -1,37 +1,88 @@
 #HierarchicalGuard
     -interface-
-    A
-    B[val:bool]
+    A [i:i16]
+    B [i:i16]
 
     -machine-
-    $I
-        |>| entered("I") ^
-        |<| left("I") ^
-        |A| -> $S0 ^
-    
+    $I  |>| -> $S ^
+
     $S
-        |>| entered("S") ^
-        |<| left("S") ^
-        |B| [val:bool] 
-            val ? : -> "|B| | val == false" $I :: :>
+        |A| [i:i16]
+            log("S.A")
+            i < 10 ?
+                -> $S0
+            :
+                -> $S1
+            :: ^
+
+        |B| [i:i16]
+            log("S.B")
+            i < 10 ?
+                -> $S2
+            :
+                -> $S3
+            :: ^
 
     $S0 => $S
-        |>| entered("S0") ^
-        |<| left("S0") ^
-        |B| [val:bool]
-            val ? -> "|B| | val == true"  $S1 : :: :>
+        |A| [i:i16]
+            log("S0.A")
+            i > 0 ?
+                -> $S2
+            :            --- fall through else branch
+            :: :>
 
-    $S1 => $S
-        |>| entered("S1") ^
-        |<| left("S1") ^
-        |B| [val:bool]
-            val ? -> "|B| | val == true" $S0 : :: :>
+        |B| [i:i16]
+            log("S0.B")
+            i > 0 ?
+            :            --- fall through then branch
+                -> $S1
+            :: :>
+
+    $S1 => $S0
+        |A| [i:i16]
+            log("S1.A")
+            i > 5 ?
+                -> $S3
+            :            --- fall through else branch
+            :: :>
+
+    $S2 => $S1
+        |A| [i:i16]
+            log("S2.A")
+            i > 10 ?
+                -> $S4
+            :            --- fall through then branch
+            :: :>
+
+        |B| [i:i16]
+            log("S2.B")
+            i > 10 ?!
+            :            --- fall through then branch
+                -> $S4
+            :: :>
+
+    $S3 => $S
+        |A| [i:i16]
+            log("S3.A")
+            i > 0 ?
+                log("stop") ^
+            :
+                log("continue")
+            :: :>
+
+        |B| [i:i16]
+            log("S3.B")
+            i > 0 ?
+                log("continue")
+            :
+                log("stop") ^
+            :: :>
+
+    $S4
 
     -actions-
-    entered[msg:&String]
-    left[msg:&String]
+    log [msg:String]
 
     -domain-
-    var entry_log:Log = `vec![]`
-    var exit_log:Log = `vec![]`
+    var tape:Log = `vec![]`
 ##

--- a/framec_tests/src/hierarchical_guard.frm
+++ b/framec_tests/src/hierarchical_guard.frm
@@ -12,20 +12,20 @@
     $S
         |>| entered("S") ^
         |<| left("S") ^
-        |B|[val:bool] 
-            val ? : -> "|B| | val == false" $I :: ^
+        |B| [val:bool] 
+            val ? : -> "|B| | val == false" $I :: :>
 
     $S0 => $S
         |>| entered("S0") ^
         |<| left("S0") ^
-        |B|[val:bool]
-            val ? -> "|B| | val == true"  $S1 : :: ^
+        |B| [val:bool]
+            val ? -> "|B| | val == true"  $S1 : :: :>
 
     $S1 => $S
         |>| entered("S1") ^
         |<| left("S1") ^
-        |B|[val:bool]
-            val ? -> "|B| | val == true" $S0 : :: ^
+        |B| [val:bool]
+            val ? -> "|B| | val == true" $S0 : :: :>
 
     -actions-
     entered[msg:&String]

--- a/framec_tests/src/hierarchical_guard.rs
+++ b/framec_tests/src/hierarchical_guard.rs
@@ -31,7 +31,6 @@ mod tests {
     // Revisit: parent handler for event isn't getting called if child has handler
     // regardless of wether it results on transition or not
     #[test]
-    #[ignore]
     fn hierarchical_parent_transition_handler_with_guard() {
         let mut sm = HierarchicalGuard::new();
         sm.a();

--- a/framec_tests/src/hierarchical_guard.rs
+++ b/framec_tests/src/hierarchical_guard.rs
@@ -1,12 +1,11 @@
+//! Test guarded transitions in hierarchical state machines.
+
 type Log = Vec<String>;
 include!(concat!(env!("OUT_DIR"), "/", "hierarchical_guard.rs"));
 
 impl HierarchicalGuard {
-    pub fn entered(&mut self, state: String) {
-        self.entry_log.push(state);
-    }
-    pub fn left(&mut self, state: String) {
-        self.exit_log.push(state);
+    pub fn log(&mut self, msg: String) {
+        self.tape.push(msg);
     }
     pub fn transition_hook(
         &mut self,
@@ -21,20 +20,118 @@ mod tests {
     use super::*;
 
     #[test]
-    fn hierarchical_child_transition_handler_with_guard() {
+    /// Test that basic conditional transitions work properly. In particular,
+    /// that control propagates to a parent handler if a child handler does
+    /// not transition and ends in a continue (`:>`).
+    fn propagate_to_parent() {
         let mut sm = HierarchicalGuard::new();
-        sm.a();
-        sm.b(true);
+        sm.a(0);
+        sm.tape.clear();
+        assert_eq!(sm.state, HierarchicalGuardState::S0);
+        sm.a(20);
+        assert_eq!(sm.state, HierarchicalGuardState::S2);
+        assert_eq!(sm.tape, vec!["S0.A"]);
+
+        sm = HierarchicalGuard::new();
+        sm.a(0);
+        sm.tape.clear();
+        assert_eq!(sm.state, HierarchicalGuardState::S0);
+        sm.a(-5);
+        assert_eq!(sm.state, HierarchicalGuardState::S0);
+        assert_eq!(sm.tape, vec!["S0.A", "S.A"]);
+
+        sm = HierarchicalGuard::new();
+        sm.a(0);
+        sm.tape.clear();
+        assert_eq!(sm.state, HierarchicalGuardState::S0);
+        sm.b(-5);
         assert_eq!(sm.state, HierarchicalGuardState::S1);
+        assert_eq!(sm.tape, vec!["S0.B"]);
+
+        sm = HierarchicalGuard::new();
+        sm.a(0);
+        sm.tape.clear();
+        assert_eq!(sm.state, HierarchicalGuardState::S0);
+        sm.b(5);
+        assert_eq!(sm.state, HierarchicalGuardState::S2);
+        assert_eq!(sm.tape, vec!["S0.B", "S.B"]);
     }
 
-    // Revisit: parent handler for event isn't getting called if child has handler
-    // regardless of wether it results on transition or not
     #[test]
-    fn hierarchical_parent_transition_handler_with_guard() {
+    /// Test that control propagates across across multiple levels if a
+    /// transition is not initiated.
+    fn propagate_multiple_levels() {
         let mut sm = HierarchicalGuard::new();
-        sm.a();
-        sm.b(false);
-        assert_eq!(sm.state, HierarchicalGuardState::I);
+        sm.b(0);
+        sm.tape.clear();
+        assert_eq!(sm.state, HierarchicalGuardState::S2);
+        sm.a(7);
+        assert_eq!(sm.state, HierarchicalGuardState::S3);
+        assert_eq!(sm.tape, vec!["S2.A", "S1.A"]);
+
+        sm = HierarchicalGuard::new();
+        sm.b(0);
+        sm.tape.clear();
+        assert_eq!(sm.state, HierarchicalGuardState::S2);
+        sm.a(-5);
+        assert_eq!(sm.state, HierarchicalGuardState::S0);
+        assert_eq!(sm.tape, vec!["S2.A", "S1.A", "S0.A", "S.A"]);
+    }
+
+    #[test]
+    /// Test that propagation of control skips levels that do not contain a
+    /// given handler.
+    fn propagate_skips_levels() {
+        let mut sm = HierarchicalGuard::new();
+        sm.b(0);
+        sm.tape.clear();
+        assert_eq!(sm.state, HierarchicalGuardState::S2);
+        sm.b(-5);
+        assert_eq!(sm.state, HierarchicalGuardState::S1);
+        assert_eq!(sm.tape, vec!["S2.B", "S0.B"]);
+
+        sm = HierarchicalGuard::new();
+        sm.b(0);
+        sm.tape.clear();
+        assert_eq!(sm.state, HierarchicalGuardState::S2);
+        sm.b(5);
+        assert_eq!(sm.state, HierarchicalGuardState::S2);
+        assert_eq!(sm.tape, vec!["S2.B", "S0.B", "S.B"]);
+    }
+
+    #[test]
+    /// Test that conditional returns prevent propagation to parents.
+    fn conditional_return() {
+        let mut sm = HierarchicalGuard::new();
+        sm.b(20);
+        sm.tape.clear();
+        assert_eq!(sm.state, HierarchicalGuardState::S3);
+        sm.a(5);
+        assert_eq!(sm.state, HierarchicalGuardState::S3);
+        assert_eq!(sm.tape, vec!["S3.A", "stop"]);
+
+        sm = HierarchicalGuard::new();
+        sm.b(20);
+        sm.tape.clear();
+        assert_eq!(sm.state, HierarchicalGuardState::S3);
+        sm.a(-5);
+        assert_eq!(sm.state, HierarchicalGuardState::S0);
+        assert_eq!(sm.tape, vec!["S3.A", "continue", "S.A"]);
+
+        sm = HierarchicalGuard::new();
+        sm.b(20);
+        sm.tape.clear();
+        assert_eq!(sm.state, HierarchicalGuardState::S3);
+        sm.b(-5);
+        assert_eq!(sm.state, HierarchicalGuardState::S3);
+        assert_eq!(sm.tape, vec!["S3.B", "stop"]);
+
+        sm = HierarchicalGuard::new();
+        sm.b(20);
+        sm.tape.clear();
+        assert_eq!(sm.state, HierarchicalGuardState::S3);
+        sm.b(5);
+        assert_eq!(sm.state, HierarchicalGuardState::S2);
+        assert_eq!(sm.tape, vec!["S3.B", "continue", "S.B"]);
     }
 }

--- a/framec_tests/src/lib.rs
+++ b/framec_tests/src/lib.rs
@@ -1,4 +1,5 @@
 mod basic;
+mod branch;
 mod empty;
 mod event_handler;
 mod hierarchical;

--- a/framec_tests/src/state_context.frm
+++ b/framec_tests/src/state_context.frm
@@ -6,49 +6,49 @@
     -machine-
     $Init
         |>| -> (3 5) $Foo ^
-    
+
     $Foo
         var x:i32 = 0
-        
+
         |>| [a:i32 b:i32]
             log("a" a)
             log("b" b)
             x = a * b
             log("x" x)
             ^
-        
+
         |<| [c:i32]
             log("c" c)
             x = x + c
             log("x" x)
             ^
-        
+
         |Inc|
             x = x + 1
             log("x" x)
             ^(x)
-        
+
         |Next| [arg:i32]
             var tmp = arg * 10  --- FIXME: Swapping this to 10 * arg causes a parse error!
             (10) -> (tmp) $Bar(x)
             ^
 
     $Bar [y:i32]
-        
+
         var z:i32 = 0
-        
+
         |>| [a:i32]
             log("a" a)
             log("y" y)
             z = a + y
             log("z" z)
             ^
-        
+
         |Inc|
             z = z + 1
             log("z" z)
             ^(z)
-    
+
     -actions-
     log [name:String val:i32]
 

--- a/framec_tests/src/state_params.frm
+++ b/framec_tests/src/state_params.frm
@@ -3,7 +3,7 @@
     Next
     Prev
     Log
-    
+
     -machine-
     $Init
         |Next| -> $Split(1) ^

--- a/framec_tests/src/state_vars.frm
+++ b/framec_tests/src/state_vars.frm
@@ -3,11 +3,11 @@
     X
     Y
     Z
-    
+
     -machine-
     $Init
         |>| -> $A ^
-    
+
     $A
         var x:u32 = 0
         |X| x = x + 1 ^

--- a/framec_tests/src/transition_params.frm
+++ b/framec_tests/src/transition_params.frm
@@ -1,7 +1,7 @@
 #TransitParams
     -interface-
     Next
-    
+
     -machine-
     $Init
         |>|


### PR DESCRIPTION
This includes lots of tests for conditional expressions, boolean tests, and the interaction of continue and conditional expressions in hierarchical state machines (i.e. guarded transitions).

Testing revealed a bug in the code generation for negated boolean tests (the `?!` construct), which has been fixed.

Guarded transitions were known to be broken and was one of the blocking issues for us. This PR fixes that problem by tracking in the code generator whether a transition has occurred on each control flow branch; if so, the handler returns at the end of that branch, otherwise it does not, potentially continuing to the parent handler later.

The guarded transition fix has been applied to all forms of branching but is only tested for boolean branching. Frame also supports matching on numerical ranges and strings, which "should work" but is untested for now.