### PR TITLE
Rust codegen cleanup

### DIFF
--- a/framec/src/frame_c/ast.rs
+++ b/framec/src/frame_c/ast.rs
@@ -845,7 +845,6 @@ pub enum ExprStmtType {
     },
 }
 
-
 impl TerminationAttrs for ExprStmtType {
     fn is_terminated(&self) -> bool {
         false
@@ -876,51 +875,58 @@ pub enum StatementType {
     NoStmt,
 }
 
-
 impl TerminationAttrs for StatementType {
     fn is_terminated(&self) -> bool {
         match &self {
-            StatementType::ExpressionStmt {expr_stmt_t} => {
+            StatementType::ExpressionStmt { expr_stmt_t } => {
                 return expr_stmt_t.is_terminated();
-            },
-            StatementType::TransitionStmt {transition_statement} => {
+            }
+            StatementType::TransitionStmt {
+                transition_statement,
+            } => {
                 return transition_statement.is_terminated();
-            },
-            StatementType::ChangeStateStmt {change_state_stmt} => {
+            }
+            StatementType::ChangeStateStmt { change_state_stmt } => {
                 return change_state_stmt.is_terminated();
-            },
-            StatementType::TestStmt {test_stmt_node} => {
+            }
+            StatementType::TestStmt { test_stmt_node } => {
                 return test_stmt_node.is_terminated();
-            },
-            StatementType::StateStackStmt {state_stack_operation_statement_node} => {
+            }
+            StatementType::StateStackStmt {
+                state_stack_operation_statement_node,
+            } => {
                 return false;
-            },
+            }
             StatementType::NoStmt => {
                 return false;
-            },
+            }
         }
     }
 
     fn must_be_terminated(&self) -> bool {
         match &self {
-            StatementType::ExpressionStmt {expr_stmt_t} => {
+            StatementType::ExpressionStmt { expr_stmt_t } => {
                 return expr_stmt_t.must_be_terminated();
-            },
-            StatementType::TransitionStmt {transition_statement} => {
+            }
+            StatementType::TransitionStmt {
+                transition_statement,
+            } => {
                 return transition_statement.must_be_terminated();
-            },
-            StatementType::ChangeStateStmt {change_state_stmt} => {
+            }
+            StatementType::ChangeStateStmt { change_state_stmt } => {
                 return change_state_stmt.must_be_terminated();
-            },
-            StatementType::TestStmt {test_stmt_node} => {
+            }
+            StatementType::TestStmt { test_stmt_node } => {
                 return test_stmt_node.must_be_terminated();
-            },
-            StatementType::StateStackStmt {state_stack_operation_statement_node} => {
+            }
+            StatementType::StateStackStmt {
+                state_stack_operation_statement_node,
+            } => {
                 return false;
-            },
+            }
             StatementType::NoStmt => {
                 return false;
-            },
+            }
         }
     }
 }
@@ -939,10 +945,10 @@ pub enum DeclOrStmtType {
 impl TerminationAttrs for DeclOrStmtType {
     fn is_terminated(&self) -> bool {
         match &self {
-            DeclOrStmtType::StmtT {stmt_t} => {
+            DeclOrStmtType::StmtT { stmt_t } => {
                 return stmt_t.is_terminated();
-            },
-            DeclOrStmtType::VarDeclT {..} => {
+            }
+            DeclOrStmtType::VarDeclT { .. } => {
                 return false;
             }
         }
@@ -950,10 +956,10 @@ impl TerminationAttrs for DeclOrStmtType {
 
     fn must_be_terminated(&self) -> bool {
         match &self {
-            DeclOrStmtType::StmtT {stmt_t} => {
+            DeclOrStmtType::StmtT { stmt_t } => {
                 return stmt_t.must_be_terminated();
-            },
-            DeclOrStmtType::VarDeclT {..} => {
+            }
+            DeclOrStmtType::VarDeclT { .. } => {
                 return false;
             }
         }
@@ -1168,16 +1174,16 @@ impl TerminationAttrs for ChangeStateStatementNode {
 
 pub struct TestStatementNode {
     pub test_t: TestType,
-    pub terminated:bool,
-    pub must_be_terminated:bool,
+    pub terminated: bool,
+    pub must_be_terminated: bool,
 }
 
 impl TestStatementNode {
     pub fn new(test_t: TestType) -> TestStatementNode {
         TestStatementNode {
             test_t,
-            terminated:false,
-            must_be_terminated:false,
+            terminated: false,
+            must_be_terminated: false,
         }
     }
 }
@@ -1663,8 +1669,8 @@ pub enum TestType {
 pub struct BoolTestNode {
     pub conditional_branch_nodes: Vec<BoolTestConditionalBranchNode>,
     pub else_branch_node_opt: Option<BoolTestElseBranchNode>,
-    pub terminated:bool,
-    pub must_be_terminated:bool,
+    pub terminated: bool,
+    pub must_be_terminated: bool,
 }
 
 impl BoolTestNode {
@@ -1672,7 +1678,6 @@ impl BoolTestNode {
         conditional_branch_nodes: Vec<BoolTestConditionalBranchNode>,
         else_branch_node_opt: Option<BoolTestElseBranchNode>,
     ) -> BoolTestNode {
-
         let mut terminated = true;
         let mut must_be_terminated = false;
         for branch in &conditional_branch_nodes {
@@ -1687,10 +1692,8 @@ impl BoolTestNode {
             Some(ref else_branch_node) => {
                 terminated = terminated && else_branch_node.is_terminated();
                 must_be_terminated = must_be_terminated || else_branch_node.must_be_terminated();
-            },
-            None => {
-                terminated = false
-            },
+            }
+            None => terminated = false,
         }
 
         BoolTestNode {
@@ -1725,8 +1728,8 @@ pub struct BoolTestConditionalBranchNode {
     pub expr_t: ExprType,
     pub statements: Vec<DeclOrStmtType>,
     pub branch_terminator_expr_opt: Option<TerminatorExpr>,
-    pub terminated:bool,
-    pub must_be_terminated:bool,
+    pub terminated: bool,
+    pub must_be_terminated: bool,
 }
 
 impl BoolTestConditionalBranchNode {
@@ -1755,7 +1758,6 @@ impl NodeElement for BoolTestConditionalBranchNode {
     }
 }
 
-
 impl TerminationAttrs for BoolTestConditionalBranchNode {
     fn is_terminated(&self) -> bool {
         self.terminated
@@ -1771,16 +1773,16 @@ impl TerminationAttrs for BoolTestConditionalBranchNode {
 pub struct BoolTestElseBranchNode {
     pub statements: Vec<DeclOrStmtType>,
     pub branch_terminator_expr_opt: Option<TerminatorExpr>,
-    pub terminated:bool,
-    pub must_be_terminated:bool,
+    pub terminated: bool,
+    pub must_be_terminated: bool,
 }
 
 impl BoolTestElseBranchNode {
     pub fn new(
         statements: Vec<DeclOrStmtType>,
         branch_terminator_t_opt: Option<TerminatorExpr>,
-        terminated:bool,
-        must_be_terminated:bool,
+        terminated: bool,
+        must_be_terminated: bool,
     ) -> BoolTestElseBranchNode {
         BoolTestElseBranchNode {
             statements,
@@ -1813,7 +1815,7 @@ pub struct StringMatchTestNode {
     pub expr_t: ExprType,
     pub match_branch_nodes: Vec<StringMatchTestMatchBranchNode>,
     pub else_branch_node_opt: Option<StringMatchTestElseBranchNode>,
-    pub terminated:bool,
+    pub terminated: bool,
 }
 
 impl StringMatchTestNode {
@@ -1826,7 +1828,7 @@ impl StringMatchTestNode {
             expr_t,
             match_branch_nodes,
             else_branch_node_opt,
-            terminated:false,
+            terminated: false,
         }
     }
 }
@@ -1843,7 +1845,7 @@ pub struct StringMatchTestMatchBranchNode {
     pub string_match_pattern_node: StringMatchTestPatternNode,
     pub statements: Vec<DeclOrStmtType>,
     pub branch_terminator_expr_opt: Option<TerminatorExpr>,
-    pub terminated:bool,
+    pub terminated: bool,
 }
 
 impl StringMatchTestMatchBranchNode {
@@ -1856,7 +1858,7 @@ impl StringMatchTestMatchBranchNode {
             string_match_pattern_node,
             statements,
             branch_terminator_expr_opt: branch_terminator_t_opt,
-            terminated:false,
+            terminated: false,
         }
     }
 }
@@ -1872,7 +1874,7 @@ impl NodeElement for StringMatchTestMatchBranchNode {
 pub struct StringMatchTestElseBranchNode {
     pub statements: Vec<DeclOrStmtType>,
     pub branch_terminator_expr_opt: Option<TerminatorExpr>,
-    pub terminated:bool,
+    pub terminated: bool,
 }
 
 impl StringMatchTestElseBranchNode {
@@ -1883,7 +1885,7 @@ impl StringMatchTestElseBranchNode {
         StringMatchTestElseBranchNode {
             statements,
             branch_terminator_expr_opt: branch_terminator_t_opt,
-            terminated:false,
+            terminated: false,
         }
     }
 }
@@ -1920,7 +1922,7 @@ pub struct NumberMatchTestNode {
     pub expr_t: ExprType,
     pub match_branch_nodes: Vec<NumberMatchTestMatchBranchNode>,
     pub else_branch_node_opt: Option<NumberMatchTestElseBranchNode>,
-    terminated:bool,
+    terminated: bool,
 }
 
 impl NumberMatchTestNode {
@@ -1933,7 +1935,7 @@ impl NumberMatchTestNode {
             expr_t,
             match_branch_nodes,
             else_branch_node_opt,
-            terminated:false,
+            terminated: false,
         }
     }
 }
@@ -1950,7 +1952,7 @@ pub struct NumberMatchTestMatchBranchNode {
     pub number_match_pattern_nodes: Vec<NumberMatchTestPatternNode>,
     pub statements: Vec<DeclOrStmtType>,
     pub branch_terminator_expr_opt: Option<TerminatorExpr>,
-    pub terminated:bool,
+    pub terminated: bool,
 }
 
 impl NumberMatchTestMatchBranchNode {
@@ -1963,7 +1965,7 @@ impl NumberMatchTestMatchBranchNode {
             number_match_pattern_nodes,
             statements,
             branch_terminator_expr_opt: branch_terminator_t_opt,
-            terminated:false,
+            terminated: false,
         }
     }
 }
@@ -1979,7 +1981,7 @@ impl NodeElement for NumberMatchTestMatchBranchNode {
 pub struct NumberMatchTestElseBranchNode {
     pub statements: Vec<DeclOrStmtType>,
     pub branch_terminator_expr_opt: Option<TerminatorExpr>,
-    pub terminated:bool,
+    pub terminated: bool,
 }
 
 impl NumberMatchTestElseBranchNode {
@@ -1990,7 +1992,7 @@ impl NumberMatchTestElseBranchNode {
         NumberMatchTestElseBranchNode {
             statements,
             branch_terminator_expr_opt: branch_terminator_t_opt,
-            terminated:false,
+            terminated: false,
         }
     }
 }

--- a/framec/src/frame_c/ast.rs
+++ b/framec/src/frame_c/ast.rs
@@ -533,7 +533,7 @@ pub struct EventHandlerNode {
     pub state_name: String,
     pub msg_t: MessageType,
     pub statements: Vec<DeclOrStmtType>,
-    pub terminator_node: TerminatorExpr,
+    pub terminator_node_opt: Option<TerminatorExpr>,
     pub event_symbol_rcref: Rc<RefCell<EventSymbol>>,
     // this is so we can know to declare a StateContext at the
     // top of the event handler.
@@ -547,7 +547,7 @@ impl EventHandlerNode {
         state_name: String,
         msg_t: MessageType,
         statements: Vec<DeclOrStmtType>,
-        terminator_node: TerminatorExpr,
+        terminator_node: Option<TerminatorExpr>,
         event_symbol_rcref: Rc<RefCell<EventSymbol>>,
         event_handler_has_transition: bool,
         line: usize,
@@ -557,7 +557,7 @@ impl EventHandlerNode {
             state_name,
             msg_t,
             statements,
-            terminator_node,
+            terminator_node_opt: terminator_node,
             event_symbol_rcref,
             event_handler_has_transition,
             line,

--- a/framec/src/frame_c/parser.rs
+++ b/framec/src/frame_c/parser.rs
@@ -1795,11 +1795,18 @@ impl<'a> Parser<'a> {
         }
 
         let statements = self.statements();
-
+        let mut last_statement_is_terminated = false;
+        match statements.last() {
+            Some(decl_or_stmt_t) => {
+                last_statement_is_terminated = decl_or_stmt_t.is_terminated();
+            },
+            None => {}
+        }
         let event_symbol_rcref = self.arcanum.get_event(&msg, &self.state_name_opt).unwrap();
         let ret_event_symbol_rcref = Rc::clone(&event_symbol_rcref);
-        let terminator_node = match self.event_handler_terminator(event_symbol_rcref) {
-            Ok(terminator_node) => terminator_node,
+        let terminator_node_opt = match self.event_handler_terminator(event_symbol_rcref) {
+            Ok(Some(terminator_node)) => Some(terminator_node),
+            Ok(None) => None,
             Err(_parse_error) => {
                 // TODO: this vec keeps the parser from hanging. don't know why
                 let sync_tokens = &vec![
@@ -1813,7 +1820,7 @@ impl<'a> Parser<'a> {
                 // create "dummy" node to keep processing
                 // TODO: 1) make line # an int so as to set it to -1 when it is a dummy node and 2) confirm this is the best way
                 // to keep going
-                TerminatorExpr::new(TerminatorType::Return, None, 0)
+                Some(TerminatorExpr::new(TerminatorType::Return, None, 0))
             }
         };
 
@@ -1857,7 +1864,7 @@ impl<'a> Parser<'a> {
     fn event_handler_terminator(
         &mut self,
         _: Rc<RefCell<EventSymbol>>,
-    ) -> Result<TerminatorExpr, ParseError> {
+    ) -> Result<Option<TerminatorExpr>, ParseError> {
         // let x = event_symbol_rcfef.borrow();
         // let ret_type = match &x.ret_type_opt {
         //     Some(ret_type) => ret_type.clone(),
@@ -1877,19 +1884,19 @@ impl<'a> Parser<'a> {
                 if let Err(parse_error) = self.consume(RParenTok, "Expected ')'.") {
                     return Err(parse_error);
                 }
-                Ok(TerminatorExpr::new(
+                Ok(Some(TerminatorExpr::new(
                     Return,
                     Some(expr_t),
                     self.previous().line,
-                ))
+                )))
             } else {
-                Ok(TerminatorExpr::new(Return, None, self.previous().line))
+                Ok(Some(TerminatorExpr::new(Return, None, self.previous().line)))
             }
         } else if self.match_token(&vec![TokenType::ElseContinueTok]) {
-            Ok(TerminatorExpr::new(Continue, None, self.previous().line))
+            Ok(Some(TerminatorExpr::new(Continue, None, self.previous().line)))
         } else {
-            self.error_at_current("Expected event handler terminator.");
-            return Err(ParseError::new("TODO"));
+        //    self.error_at_current("Expected event handler terminator.");
+            Ok(None)
         }
     }
 
@@ -1900,31 +1907,39 @@ impl<'a> Parser<'a> {
     // TODO: need result and optional
     fn statements(&mut self) -> Vec<DeclOrStmtType> {
         let mut statements = Vec::new();
+        let terminated = false;
 
         loop {
             // let result = self.decl_or_stmt();
+//            let must_terminate = false;
             match self.decl_or_stmt() {
                 Ok(opt_smt) => match opt_smt {
                     Some(statement) => {
 
-                        match &statement {
-                            DeclOrStmtType::StmtT {stmt_t} => {
-                                // Transitions or state changes must be the last statement in
-                                // an event handler.
-                                match stmt_t {
-                                    StatementType::TransitionStmt {transition_statement} => {
-                                        return statements;
-                                    },
-                                    StatementType::ChangeStateStmt {change_state_stmt} => {
-                                        return statements;
-                                    },
-                                    _ => {}
-                                }
-                            },
-                            _ => {}
-                        }
+                        // match &statement {
+                        //     DeclOrStmtType::StmtT {stmt_t} => {
+                        //         // Transitions or state changes must be the last statement in
+                        //         // an event handler.
+                        //         match stmt_t {
+                        //             StatementType::TransitionStmt {transition_statement} => {
+                        //                 statements.push(statement);
+                        //                 return statements;
+                        //             },
+                        //             StatementType::ChangeStateStmt {change_state_stmt} => {
+                        //                 statements.push(statement);
+                        //                 return statements;
+                        //             },
+                        //             _ => {}
+                        //         }
+                        //     },
+                        //     _ => {}
+                        // }
 
+                        let must_be_terminated = statement.must_be_terminated();
                         statements.push(statement);
+                        if must_be_terminated {
+                            return statements;
+                        }
 
                     }
                     None => {
@@ -2232,6 +2247,7 @@ impl<'a> Parser<'a> {
 
     fn bool_test(&mut self, expr_t: ExprType) -> Result<BoolTestNode, ParseError> {
         let is_negated: bool;
+        let is_terminated = true;
 
         // '?'
         if self.match_token(&vec![BoolTestTrueTok]) {
@@ -2257,6 +2273,7 @@ impl<'a> Parser<'a> {
         while self.match_token(&vec![ElseContinueTok]) {
             match self.bool_test_else_continue_branch() {
                 Ok(branch_node) => {
+
                     conditional_branches.push(branch_node);
                 }
                 Err(parse_error) => return Err(parse_error),
@@ -2329,17 +2346,47 @@ impl<'a> Parser<'a> {
         is_negated: bool,
         expr_t: ExprType,
     ) -> Result<BoolTestConditionalBranchNode, ParseError> {
+
         let statements = self.statements();
+        let mut must_be_terminated = false;
+
+        // if the last statement in the branch is a
+        // "must_be_terminated" statement then that property
+        // needs to be set on the branch as well.
+        match statements.last() {
+            Some(decl_or_stmt_t) => {
+                must_be_terminated = decl_or_stmt_t.must_be_terminated();
+            },
+            None => {}
+        }
 
         let result = self.branch_terminator();
 
+  //      let terminated;
+
+        // match result {
+        //     Ok(terminator_exp_opt) => {
+        //         terminated = terminator_exp_opt.is_some();
+        //     },
+        //     Err(parse_error) => { return Err(parse_error); }
+        // }
+        // if terminated && result.is_some() {
+        //     return Err(ParseError::new("Unnecessary branch terminator."));
+        // }
         return match result {
-            Ok(branch_terminator_t_opt) => Ok(BoolTestConditionalBranchNode::new(
-                is_negated,
-                expr_t,
-                statements,
-                branch_terminator_t_opt,
-            )),
+            Ok(branch_terminator_expr_opt) => {
+
+                let terminated = branch_terminator_expr_opt.is_some();
+
+                Ok(BoolTestConditionalBranchNode::new(
+                    is_negated,
+                    expr_t,
+                    statements,
+                    branch_terminator_expr_opt,
+                    terminated,
+                    must_be_terminated,
+                ))
+            }
             Err(parse_error) => Err(parse_error),
         };
     }
@@ -2350,21 +2397,37 @@ impl<'a> Parser<'a> {
 
     fn bool_test_else_branch(&mut self) -> Result<BoolTestElseBranchNode, ParseError> {
         let statements = self.statements();
+        let mut must_be_terminated = false;
+       // if the last statement in the branch is a
+        // "must_be_terminated" statement then that property
+        // needs to be set on the branch as well.
+        match statements.last() {
+            Some(decl_or_stmt_t) => {
+                must_be_terminated = decl_or_stmt_t.must_be_terminated();
+            },
+            None => {}
+        }
 
         let result = self.branch_terminator();
 
         return match result {
-            Ok(branch_terminator_opt) => Ok(BoolTestElseBranchNode::new(
-                statements,
-                branch_terminator_opt,
-            )),
+            Ok(branch_terminator_expr_opt) => {
+                let terminated = branch_terminator_expr_opt.is_some();
+
+                Ok(BoolTestElseBranchNode::new(
+                    statements,
+                    branch_terminator_expr_opt,
+                    terminated,
+                    must_be_terminated,
+                ))
+            }
             Err(parse_error) => Err(parse_error),
         };
     }
 
     /* --------------------------------------------------------------------- */
 
-    // branch_terminator -> ^ | '>'
+    // branch_terminator -> '^' | ':>'
 
     // TODO: explore returning a TerminatorType rather than node
     fn branch_terminator(&mut self) -> Result<Option<TerminatorExpr>, ParseError> {

--- a/framec/src/frame_c/parser.rs
+++ b/framec/src/frame_c/parser.rs
@@ -1849,7 +1849,7 @@ impl<'a> Parser<'a> {
             st_name.clone(),
             message_type,
             statements,
-            terminator_node,
+            terminator_node_opt,
             ret_event_symbol_rcref,
             self.event_handler_has_transition,
             line_number,

--- a/framec/src/frame_c/parser.rs
+++ b/framec/src/frame_c/parser.rs
@@ -10,12 +10,12 @@ use super::scanner::TokenType::*;
 use super::scanner::*;
 use super::symbol_table::SymbolType::*;
 use super::symbol_table::*;
+use crate::frame_c::ast::StatementType::TransitionStmt;
 use crate::frame_c::utils::SystemHierarchy;
 use downcast_rs::__std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
-use crate::frame_c::ast::StatementType::TransitionStmt;
 
 pub struct ParseError {
     // TODO:
@@ -1799,7 +1799,7 @@ impl<'a> Parser<'a> {
         match statements.last() {
             Some(decl_or_stmt_t) => {
                 last_statement_is_terminated = decl_or_stmt_t.is_terminated();
-            },
+            }
             None => {}
         }
         let event_symbol_rcref = self.arcanum.get_event(&msg, &self.state_name_opt).unwrap();
@@ -1890,12 +1890,20 @@ impl<'a> Parser<'a> {
                     self.previous().line,
                 )))
             } else {
-                Ok(Some(TerminatorExpr::new(Return, None, self.previous().line)))
+                Ok(Some(TerminatorExpr::new(
+                    Return,
+                    None,
+                    self.previous().line,
+                )))
             }
         } else if self.match_token(&vec![TokenType::ElseContinueTok]) {
-            Ok(Some(TerminatorExpr::new(Continue, None, self.previous().line)))
+            Ok(Some(TerminatorExpr::new(
+                Continue,
+                None,
+                self.previous().line,
+            )))
         } else {
-        //    self.error_at_current("Expected event handler terminator.");
+            //    self.error_at_current("Expected event handler terminator.");
             Ok(None)
         }
     }
@@ -1911,11 +1919,10 @@ impl<'a> Parser<'a> {
 
         loop {
             // let result = self.decl_or_stmt();
-//            let must_terminate = false;
+            //            let must_terminate = false;
             match self.decl_or_stmt() {
                 Ok(opt_smt) => match opt_smt {
                     Some(statement) => {
-
                         // match &statement {
                         //     DeclOrStmtType::StmtT {stmt_t} => {
                         //         // Transitions or state changes must be the last statement in
@@ -1940,12 +1947,10 @@ impl<'a> Parser<'a> {
                         if must_be_terminated {
                             return statements;
                         }
-
                     }
                     None => {
                         return statements;
                     }
-
                 },
                 Err(_err) => {
                     let sync_tokens = &vec![
@@ -2273,7 +2278,6 @@ impl<'a> Parser<'a> {
         while self.match_token(&vec![ElseContinueTok]) {
             match self.bool_test_else_continue_branch() {
                 Ok(branch_node) => {
-
                     conditional_branches.push(branch_node);
                 }
                 Err(parse_error) => return Err(parse_error),
@@ -2346,7 +2350,6 @@ impl<'a> Parser<'a> {
         is_negated: bool,
         expr_t: ExprType,
     ) -> Result<BoolTestConditionalBranchNode, ParseError> {
-
         let statements = self.statements();
         let mut must_be_terminated = false;
 
@@ -2356,13 +2359,13 @@ impl<'a> Parser<'a> {
         match statements.last() {
             Some(decl_or_stmt_t) => {
                 must_be_terminated = decl_or_stmt_t.must_be_terminated();
-            },
+            }
             None => {}
         }
 
         let result = self.branch_terminator();
 
-  //      let terminated;
+        //      let terminated;
 
         // match result {
         //     Ok(terminator_exp_opt) => {
@@ -2375,7 +2378,6 @@ impl<'a> Parser<'a> {
         // }
         return match result {
             Ok(branch_terminator_expr_opt) => {
-
                 let terminated = branch_terminator_expr_opt.is_some();
 
                 Ok(BoolTestConditionalBranchNode::new(
@@ -2398,13 +2400,13 @@ impl<'a> Parser<'a> {
     fn bool_test_else_branch(&mut self) -> Result<BoolTestElseBranchNode, ParseError> {
         let statements = self.statements();
         let mut must_be_terminated = false;
-       // if the last statement in the branch is a
+        // if the last statement in the branch is a
         // "must_be_terminated" statement then that property
         // needs to be set on the branch as well.
         match statements.last() {
             Some(decl_or_stmt_t) => {
                 must_be_terminated = decl_or_stmt_t.must_be_terminated();
-            },
+            }
             None => {}
         }
 

--- a/framec/src/frame_c/visitors/cpp_visitor.rs
+++ b/framec/src/frame_c/visitors/cpp_visitor.rs
@@ -1351,8 +1351,11 @@ impl AstVisitor for CppVisitor {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node = &evt_handler_node.terminator_node;
-        terminator_node.accept(self);
+        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
+        if let Some(terminator_node) = terminator_node_opt {
+            terminator_node.accept(self);
+        }
+
         self.outdent();
 
         self.newline();

--- a/framec/src/frame_c/visitors/cs_visitor.rs
+++ b/framec/src/frame_c/visitors/cs_visitor.rs
@@ -1432,8 +1432,10 @@ impl AstVisitor for CsVisitor {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node = &evt_handler_node.terminator_node;
-        terminator_node.accept(self);
+        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
+        if let Some(terminator_node) = terminator_node_opt {
+            terminator_node.accept(self);
+        }
         self.outdent();
         self.newline();
         self.add_code(&format!("}}"));

--- a/framec/src/frame_c/visitors/cs_visitor_for_bob.rs
+++ b/framec/src/frame_c/visitors/cs_visitor_for_bob.rs
@@ -1479,8 +1479,10 @@ impl AstVisitor for CsVisitorForBob {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node = &evt_handler_node.terminator_node;
-        terminator_node.accept(self);
+        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
+        if let Some(terminator_node) = terminator_node_opt {
+            terminator_node.accept(self);
+        }
         self.outdent();
 
         self.newline();

--- a/framec/src/frame_c/visitors/gdscript_3_2_visitor.rs
+++ b/framec/src/frame_c/visitors/gdscript_3_2_visitor.rs
@@ -1307,8 +1307,10 @@ impl AstVisitor for GdScript32Visitor {
         self.visit_decl_stmts(&evt_handler_node.statements);
 
         self.event_handler_has_code = evt_handler_node.statements.len() > 0usize;
-        let terminator_node = &evt_handler_node.terminator_node;
-        terminator_node.accept(self);
+        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
+        if let Some(terminator_node) = terminator_node_opt {
+            terminator_node.accept(self);
+        }
         self.outdent();
         self.newline();
 

--- a/framec/src/frame_c/visitors/java_8_visitor.rs
+++ b/framec/src/frame_c/visitors/java_8_visitor.rs
@@ -1431,8 +1431,10 @@ impl AstVisitor for Java8Visitor {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node = &evt_handler_node.terminator_node;
-        terminator_node.accept(self);
+        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
+        if let Some(terminator_node) = terminator_node_opt {
+            terminator_node.accept(self);
+        }
         self.outdent();
         self.newline();
         self.add_code(&format!("}}"));

--- a/framec/src/frame_c/visitors/javascript_visitor.rs
+++ b/framec/src/frame_c/visitors/javascript_visitor.rs
@@ -1356,8 +1356,10 @@ impl AstVisitor for JavaScriptVisitor {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node = &evt_handler_node.terminator_node;
-        terminator_node.accept(self);
+        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
+        if let Some(terminator_node) = terminator_node_opt {
+            terminator_node.accept(self);
+        }
         self.outdent();
         self.newline();
         self.add_code(&format!("}}"));

--- a/framec/src/frame_c/visitors/plantuml_visitor.rs
+++ b/framec/src/frame_c/visitors/plantuml_visitor.rs
@@ -1249,12 +1249,10 @@ impl AstVisitor for PlantUmlVisitor {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node = &evt_handler_node.terminator_node;
-        terminator_node.accept(self);
-        // self.outdent();
-        //
-        // self.newline();
-        // self.add_code(&format!("}}"));
+        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
+        if let Some(terminator_node) = terminator_node_opt {
+            terminator_node.accept(self);
+        }
 
         // this controls formatting here
         self.first_event_handler = false;

--- a/framec/src/frame_c/visitors/python_visitor.rs
+++ b/framec/src/frame_c/visitors/python_visitor.rs
@@ -1323,8 +1323,10 @@ impl AstVisitor for PythonVisitor {
         self.visit_decl_stmts(&evt_handler_node.statements);
 
         self.event_handler_has_code = evt_handler_node.statements.len() > 0usize;
-        let terminator_node = &evt_handler_node.terminator_node;
-        terminator_node.accept(self);
+        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
+        if let Some(terminator_node) = terminator_node_opt {
+            terminator_node.accept(self);
+        }
         self.outdent();
         self.newline();
 

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -2942,6 +2942,8 @@ impl AstVisitor for RustVisitor {
     ) -> AstVisitorReturnType {
         if self.config.config_features.generate_action_impl {
             self.newline();
+            self.add_code("#[allow(unused_variables)]");
+            self.newline();
             self.add_code(&format!(
                 "impl {}{}{} for {} {{ ",
                 self.config.actions_prefix,

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -3059,8 +3059,10 @@ impl AstVisitor for RustVisitor {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node = &evt_handler_node.terminator_node;
-        terminator_node.accept(self);
+        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
+        if let Some(terminator_node) = terminator_node_opt {
+            terminator_node.accept(self);
+        }
         self.outdent();
         self.newline();
         self.add_code(&format!("}}"));

--- a/framec_tests/src/basic.rs
+++ b/framec_tests/src/basic.rs
@@ -8,7 +8,6 @@ impl Basic {
     pub fn left(&mut self, state: String) {
         self.exit_log.push(state);
     }
-    pub fn transition_hook(&mut self, _current: BasicState, _next: BasicState) {}
 }
 
 #[cfg(test)]

--- a/framec_tests/src/branch.rs
+++ b/framec_tests/src/branch.rs
@@ -7,7 +7,6 @@ impl Branch {
     pub fn log(&mut self, msg: String) {
         self.tape.push(msg);
     }
-    pub fn transition_hook(&mut self, _current: BranchState, _next: BranchState) {}
 }
 
 #[cfg(test)]

--- a/framec_tests/src/event_handler.rs
+++ b/framec_tests/src/event_handler.rs
@@ -7,7 +7,6 @@ impl EventHandler {
     pub fn log(&mut self, msg: String, val: i32) {
         self.tape.push(format!("{}={}", msg, val));
     }
-    pub fn transition_hook(&mut self, _current: EventHandlerState, _next: EventHandlerState) {}
 }
 
 #[cfg(test)]

--- a/framec_tests/src/hierarchical.rs
+++ b/framec_tests/src/hierarchical.rs
@@ -13,7 +13,6 @@ impl Hierarchical {
     pub fn log(&mut self, msg: String) {
         self.tape.push(msg);
     }
-    pub fn transition_hook(&mut self, _current: HierarchicalState, _next: HierarchicalState) {}
 }
 
 #[cfg(test)]

--- a/framec_tests/src/hierarchical_guard.rs
+++ b/framec_tests/src/hierarchical_guard.rs
@@ -7,12 +7,6 @@ impl HierarchicalGuard {
     pub fn log(&mut self, msg: String) {
         self.tape.push(msg);
     }
-    pub fn transition_hook(
-        &mut self,
-        _current: HierarchicalGuardState,
-        _next: HierarchicalGuardState,
-    ) {
-    }
 }
 
 #[cfg(test)]

--- a/framec_tests/src/lib.rs
+++ b/framec_tests/src/lib.rs
@@ -4,6 +4,7 @@ mod empty;
 mod event_handler;
 mod hierarchical;
 mod hierarchical_guard;
+mod rust_naming;
 mod state_context;
 mod state_params;
 mod state_vars;

--- a/framec_tests/src/rust_naming.frm
+++ b/framec_tests/src/rust_naming.frm
@@ -1,0 +1,98 @@
+#[follow_rust_naming="true"]
+#RustNaming
+    -interface-
+    snake_event [snake_param:i32]
+    CamelEvent [CamelParam:i32]
+    event123 [param123:i32]
+
+    -machine-
+    $Init
+        |snake_event| [snake_param:i32]
+            -> $snake_state(snake_param) ^
+
+        |CamelEvent| [CamelParam:i32]
+            -> $CamelState(CamelParam) ^
+
+        |event123| [param123:i32]
+            -> $state123(param123) ^
+
+    $snake_state [snake_state_param:i32]
+
+        --- 1100
+        var snake_state_var:i32 = snake_domain_var + CamelDomainVar + domainVar123 + 100
+
+        |snake_event| [snake_param:i32]
+            var snake_local_var:i32 = snake_state_var + snake_state_param + snake_param
+            snake_action(snake_local_var)
+            -> $Final(snake_local_var) ^
+
+        |CamelEvent| [CamelParam:i32]
+            var CamelLocalVar:i32 = snake_state_var + snake_state_param + CamelParam
+            CamelAction(CamelLocalVar)
+            -> $Final(CamelLocalVar) ^
+
+        |event123| [param123:i32]
+            var localVar123:i32 = snake_state_var + snake_state_param + param123
+            action123(localVar123)
+            -> $Final(localVar123) ^
+
+    $CamelState [CamelStateParam:i32]
+
+        --- 1200
+        var CamelStateVar:i32 = snake_domain_var + CamelDomainVar + domainVar123 + 200
+
+        |snake_event| [snake_param:i32]
+            var snake_local_var:i32 = CamelStateVar + CamelStateParam + snake_param
+            snake_action(snake_local_var)
+            -> $Final(snake_local_var) ^
+
+        |CamelEvent| [CamelParam:i32]
+            var CamelLocalVar:i32 = CamelStateVar + CamelStateParam + CamelParam
+            CamelAction(CamelLocalVar)
+            -> $Final(CamelLocalVar) ^
+
+        |event123| [param123:i32]
+            var localVar123:i32 = CamelStateVar + CamelStateParam + param123
+            action123(localVar123)
+            -> $Final(localVar123) ^
+
+    $state123 [stateParam123:i32]
+
+        --- 1300
+        var stateVar123:i32 = snake_domain_var + CamelDomainVar + domainVar123 + 300
+
+        |snake_event| [snake_param:i32]
+            var snake_local_var:i32 = stateVar123 + stateParam123 + snake_param
+            snake_action(snake_local_var)
+            -> $Final(snake_local_var) ^
+
+        |CamelEvent| [CamelParam:i32]
+            var CamelLocalVar:i32 = stateVar123 + stateParam123 + CamelParam
+            CamelAction(CamelLocalVar)
+            -> $Final(CamelLocalVar) ^
+
+        |event123| [param123:i32]
+            var localVar123:i32 = stateVar123 + stateParam123 + param123
+            action123(localVar123)
+            -> $Final(localVar123) ^
+
+    $Final [result:i32]
+        |>|
+            logFinal(result)
+            -> $Init ^
+
+    -actions-
+    snake_action [snake_param:i32]
+    CamelAction [CamelParam:i32]
+    action123 [param123:i32]
+    logFinal [r:i32]
+
+    -domain-
+    var snake_domain_var:i32 = 300
+    var CamelDomainVar:i32 = 550
+    var domainVar123:i32 = 150
+    var snake_log:Log = `vec![]`
+    var CamelLog:Log = `vec![]`
+    var log123:Log = `vec![]`
+    var finalLog:Log = `vec![]`
+##

--- a/framec_tests/src/rust_naming.rs
+++ b/framec_tests/src/rust_naming.rs
@@ -16,7 +16,6 @@ impl RustNaming {
     pub fn log_final(&mut self, arg: i32) {
         self.final_log.push(arg);
     }
-    pub fn transition_hook(&mut self, _current: RustNamingState, _next: RustNamingState) {}
 }
 
 #[cfg(test)]

--- a/framec_tests/src/rust_naming.rs
+++ b/framec_tests/src/rust_naming.rs
@@ -1,0 +1,86 @@
+//! Test the coverage of the `follow_rust_naming` feature.
+
+type Log = Vec<i32>;
+include!(concat!(env!("OUT_DIR"), "/", "rust_naming.rs"));
+
+impl RustNaming {
+    pub fn snake_action(&mut self, arg: i32) {
+        self.snake_log.push(arg);
+    }
+    pub fn camel_action(&mut self, arg: i32) {
+        self.camel_log.push(arg);
+    }
+    pub fn action_123(&mut self, arg: i32) {
+        self.log_123.push(arg);
+    }
+    pub fn log_final(&mut self, arg: i32) {
+        self.final_log.push(arg);
+    }
+    pub fn transition_hook(&mut self, _current: RustNamingState, _next: RustNamingState) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// Test that the generated file compiles.
+    fn follow_rust_naming_compiles() {
+        assert!(true);
+    }
+
+    #[test]
+    /// Test that the generated state machine works and that events are
+    /// named as expected.
+    fn follow_rust_naming_works() {
+        let mut sm = RustNaming::new();
+
+        sm.snake_event(1);
+        assert_eq!(sm.state, RustNamingState::SnakeState);
+        sm.snake_event(2);
+        assert_eq!(sm.state, RustNamingState::Init);
+        sm.snake_event(1);
+        assert_eq!(sm.state, RustNamingState::SnakeState);
+        sm.camel_event(3);
+        assert_eq!(sm.state, RustNamingState::Init);
+        sm.snake_event(1);
+        assert_eq!(sm.state, RustNamingState::SnakeState);
+        sm.event_123(4);
+        assert_eq!(sm.state, RustNamingState::Init);
+        assert_eq!(sm.final_log, vec![1103, 1104, 1105]);
+        sm.final_log.clear();
+
+        sm.camel_event(11);
+        assert_eq!(sm.state, RustNamingState::CamelState);
+        sm.snake_event(2);
+        assert_eq!(sm.state, RustNamingState::Init);
+        sm.camel_event(11);
+        assert_eq!(sm.state, RustNamingState::CamelState);
+        sm.camel_event(3);
+        assert_eq!(sm.state, RustNamingState::Init);
+        sm.camel_event(11);
+        assert_eq!(sm.state, RustNamingState::CamelState);
+        sm.event_123(4);
+        assert_eq!(sm.state, RustNamingState::Init);
+        assert_eq!(sm.final_log, vec![1213, 1214, 1215]);
+        sm.final_log.clear();
+
+        sm.event_123(21);
+        assert_eq!(sm.state, RustNamingState::State123);
+        sm.snake_event(2);
+        assert_eq!(sm.state, RustNamingState::Init);
+        sm.event_123(21);
+        assert_eq!(sm.state, RustNamingState::State123);
+        sm.camel_event(3);
+        assert_eq!(sm.state, RustNamingState::Init);
+        sm.event_123(21);
+        assert_eq!(sm.state, RustNamingState::State123);
+        sm.event_123(4);
+        assert_eq!(sm.state, RustNamingState::Init);
+        assert_eq!(sm.final_log, vec![1323, 1324, 1325]);
+
+        assert_eq!(sm.snake_log, vec![1103, 1213, 1323]);
+        assert_eq!(sm.camel_log, vec![1104, 1214, 1324]);
+        assert_eq!(sm.log_123, vec![1105, 1215, 1325]);
+    }
+}

--- a/framec_tests/src/state_context.rs
+++ b/framec_tests/src/state_context.rs
@@ -9,8 +9,6 @@ impl StateContextSm {
     pub fn log(&mut self, name: String, val: i32) {
         self.tape.push(format!("{}={}", name, val));
     }
-
-    pub fn transition_hook(&mut self, _current: StateContextSmState, _next: StateContextSmState) {}
 }
 
 #[cfg(test)]

--- a/framec_tests/src/state_params.rs
+++ b/framec_tests/src/state_params.rs
@@ -5,7 +5,6 @@ impl StateParams {
     pub fn got_param(&mut self, name: String, val: u32) {
         self.param_log.push(format!("{}={}", name, val));
     }
-    pub fn transition_hook(&mut self, _current: StateParamsState, _next: StateParamsState) {}
 }
 
 #[cfg(test)]

--- a/framec_tests/src/state_vars.rs
+++ b/framec_tests/src/state_vars.rs
@@ -1,9 +1,5 @@
 include!(concat!(env!("OUT_DIR"), "/", "state_vars.rs"));
 
-impl StateVars {
-    pub fn transition_hook(&mut self, _current: StateVarsState, _next: StateVarsState) {}
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/framec_tests/src/transition_params.rs
+++ b/framec_tests/src/transition_params.rs
@@ -11,7 +11,6 @@ impl TransitParams {
     pub fn exited(&mut self, val: bool, msg: String) {
         self.exit_log.push(format!("{} {}", val, msg));
     }
-    pub fn transition_hook(&mut self, _current: TransitParamsState, _next: TransitParamsState) {}
 }
 
 #[cfg(test)]

--- a/framec_tests/src/var_scope.rs
+++ b/framec_tests/src/var_scope.rs
@@ -21,8 +21,6 @@ impl VarScope {
         self.tape.push(s);
     }
 
-    pub fn transition_hook(&mut self, _current: VarScopeState, _next: VarScopeState) {}
-
     pub fn do_nn(&mut self) {
         self.nn("|nn|[d]".to_string());
     }


### PR DESCRIPTION
This includes tests and several fixes to the `follow_rust_naming` feature.

It also moves the transition and change-state hook methods into the state machine's action trait. This has the benefit of collecting all of the methods that a user must implement into one trait, rather than the current solution of just blindly calling a method that may or may not be implemented. If `generate_action_impl` is enabled, empty default implementations of the hook methods are generated.