### PR TITLE
Tests and fixes for transition functions and corresponding hook methods

### DIFF
--- a/framec/src/frame_c/default_config.yaml
+++ b/framec/src/frame_c/default_config.yaml
@@ -6,6 +6,7 @@ codegen:
   rust:
     features:
       generate_action_impl: true
+      generate_hook_methods: true
       follow_rust_naming: true
     code:
       actions_prefix:

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -1576,8 +1576,8 @@ impl RustVisitor {
         self.add_code(&format!(
             "self.{}({}::{});",
             self.config.change_state_method_name,
-            self.system_name,
-            self.format_state_handler_name(target_state_name)
+            self.state_enum_type_name(),
+            self.format_type_name(&target_state_name.to_string())
         ));
     }
 

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -2277,18 +2277,21 @@ impl AstVisitor for RustVisitor {
         self.newline();
         self.newline();
         self.generate_state_enum(&system_node);
-        self.newline();
-        self.newline();
 
         if self.generate_state_context {
+            self.newline();
+            self.newline();
             self.generate_state_context_defs(&system_node);
         }
 
         if let Some(actions_block_node) = &system_node.actions_block_node_opt {
+            self.newline();
+            self.newline();
             actions_block_node.accept_rust_trait(self);
         }
-        self.newline();
 
+        self.newline();
+        self.newline();
         self.add_code("// System Controller ");
         self.newline();
         if !self.config.config_features.follow_rust_naming {
@@ -2939,8 +2942,6 @@ impl AstVisitor for RustVisitor {
         actions_block_node: &ActionsBlockNode,
     ) -> AstVisitorReturnType {
         if self.config.config_features.generate_action_impl {
-            self.newline();
-            self.newline();
             self.add_code(&format!(
                 "trait {}{}{} {{ ",
                 self.config.actions_prefix, self.system_name, self.config.actions_suffix
@@ -2978,7 +2979,6 @@ impl AstVisitor for RustVisitor {
             self.outdent();
             self.newline();
             self.add_code("}");
-            self.newline();
         }
 
         AstVisitorReturnType::ActionBlockNode {}

--- a/framec_tests/src/hierarchical.frm
+++ b/framec_tests/src/hierarchical.frm
@@ -55,9 +55,9 @@
             -> $S3 ^
 
     -actions-
-    enter[msg:String]
-    exit[msg:String]
-    log[msg:String]
+    enter [msg:String]
+    exit [msg:String]
+    log [msg:String]
 
     -domain-
     var enters:Log = `vec![]`

--- a/framec_tests/src/lib.rs
+++ b/framec_tests/src/lib.rs
@@ -8,5 +8,6 @@ mod rust_naming;
 mod state_context;
 mod state_params;
 mod state_vars;
+mod transition;
 mod transition_params;
 mod var_scope;

--- a/framec_tests/src/transition.frm
+++ b/framec_tests/src/transition.frm
@@ -1,0 +1,53 @@
+#Transition
+    -interface-
+    transit
+    change
+
+    -machine-
+    $S0
+        |>| enter("S0") ^
+        |<| exit("S0") ^
+        |transit|
+            -> $S1 ^
+        |change|
+            ->> $S1 ^
+
+    $S1
+        |>| enter("S1") ^
+        |<| exit("S1") ^
+        |transit|
+            -> $S2 ^
+        |change|
+            ->> $S2 ^
+
+    $S2
+        |>| enter("S2")
+            -> $S3 ^
+        |<| exit("S2") ^
+        |transit|
+            -> $S3 ^
+        |change|
+            ->> $S3 ^
+
+    $S3
+        |>| enter("S3") ^
+        |<| exit("S3") ^
+        |transit|
+            -> $S4 ^
+        |change|
+            ->> $S4 ^
+
+    $S4
+        |>| enter("S4")
+            ->> $S0 ^
+        |<| exit("S4") ^
+
+    -actions-
+    enter [state:String]
+    exit [state:String]
+
+    -domain-
+    var enters:Log = `vec![]`
+    var exits:Log = `vec![]`
+    var hooks:Log = `vec![]`
+##

--- a/framec_tests/src/transition.rs
+++ b/framec_tests/src/transition.rs
@@ -1,0 +1,129 @@
+//! Frame supports two different operations for changing the current state of
+//! the machine: "change-state" (`->>`) which simply changes to the new state,
+//! and "transition" (`->`), which also sends an exit event to the old state
+//! and an enter event to the new state.
+//!
+//! This file tests that these operations work correctly. It also tests that
+//! the optional hook methods for each operation are invoked when states are
+//! changed.
+//!
+//! Note that the change-state operation is only partially implemented. It
+//! does not support any features that require a state context (e.g. state
+//! variables and state parameters).
+
+type Log = Vec<String>;
+include!(concat!(env!("OUT_DIR"), "/", "transition.rs"));
+
+#[allow(dead_code)]
+impl Transition {
+    pub fn enter(&mut self, state: String) {
+        self.enters.push(state);
+    }
+    pub fn exit(&mut self, state: String) {
+        self.exits.push(state);
+    }
+    pub fn transition_hook(&mut self, old_state: TransitionState, new_state: TransitionState) {
+        let s = format!("{:?}->{:?}", old_state, new_state);
+        self.hooks.push(s);
+    }
+    pub fn change_state_hook(&mut self, old_state: TransitionState, new_state: TransitionState) {
+        let s = format!("{:?}->>{:?}", old_state, new_state);
+        self.hooks.push(s);
+    }
+    pub fn clear_all(&mut self) {
+        self.enters.clear();
+        self.exits.clear();
+        self.hooks.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// Test that transition works and triggers enter and exit events.
+    fn transition_events() {
+        let mut sm = Transition::new();
+        sm.clear_all();
+        sm.transit();
+        assert_eq!(sm.state, TransitionState::S1);
+        assert_eq!(sm.exits, vec!["S0"]);
+        assert_eq!(sm.enters, vec!["S1"]);
+    }
+
+    #[test]
+    /// Test that change-state works and does not trigger events.
+    fn change_state_no_events() {
+        let mut sm = Transition::new();
+        sm.clear_all();
+        sm.change();
+        assert_eq!(sm.state, TransitionState::S1);
+        sm.change();
+        assert_eq!(sm.state, TransitionState::S2);
+        sm.change();
+        assert_eq!(sm.state, TransitionState::S3);
+        sm.change();
+        assert_eq!(sm.state, TransitionState::S4);
+        assert!(sm.exits.is_empty());
+        assert!(sm.enters.is_empty());
+    }
+
+    #[test]
+    /// Test transition that triggers another transition in an enter event
+    /// handler.
+    fn cascading_transition() {
+        let mut sm = Transition::new();
+        sm.change();
+        sm.clear_all();
+        assert_eq!(sm.state, TransitionState::S1);
+        sm.transit();
+        assert_eq!(sm.state, TransitionState::S3);
+        assert_eq!(sm.exits, vec!["S1", "S2"]);
+        assert_eq!(sm.enters, vec!["S2", "S3"]);
+    }
+
+    #[test]
+    /// Test transition that triggers a change-state from an enter event
+    /// handler.
+    fn cascading_change_state() {
+        let mut sm = Transition::new();
+        sm.change();
+        sm.change();
+        sm.change();
+        sm.clear_all();
+        assert_eq!(sm.state, TransitionState::S3);
+        sm.transit();
+        assert_eq!(sm.state, TransitionState::S0);
+        assert_eq!(sm.exits, vec!["S3"]);
+        assert_eq!(sm.enters, vec!["S4"]);
+    }
+
+    #[test]
+    /// Test transition hook method.
+    fn transition_hook() {
+        let mut sm = Transition::new();
+        sm.transit();
+        assert_eq!(sm.hooks, vec!["S0->S1"]);
+        sm.clear_all();
+        sm.transit();
+        assert_eq!(sm.hooks, vec!["S1->S2", "S2->S3"]);
+    }
+
+    #[test]
+    /// Test change-state hook method.
+    fn change_state_hook() {
+        let mut sm = Transition::new();
+        sm.change();
+        assert_eq!(sm.hooks, vec!["S0->>S1"]);
+        sm.clear_all();
+        sm.change();
+        assert_eq!(sm.hooks, vec!["S1->>S2"]);
+        sm.clear_all();
+        sm.change();
+        assert_eq!(sm.hooks, vec!["S2->>S3"]);
+        sm.clear_all();
+        sm.transit();
+        assert_eq!(sm.hooks, vec!["S3->S4", "S4->>S0"]);
+    }
+}


### PR DESCRIPTION
This provides tests and fixes for the `transition` and `change_state` functions. It also tests the optional hook methods feature for each of these.

The interface to the hook methods feature has been changed a bit to make it more consistent with other features.

There are two configuration options specifying the names of optional hook methods: `transition_hook_method_name` and `change_state_hook_method_name`.

Previously, a hook method was generated if the corresponding option was not the empty string (and not generated otherwise). None of the other configuration options work this way, however.

Now, there is a new feature option `generate_hook_methods`. If this is true, the hook methods are generated, and the `_method_name` options are used to determine their names.

If the feature option is true but the corresponding `_method_name` options are undefined or the empty string, Frame will generate invalid code. However, this is also the case with most of the existing configuration options and so requires a more general solution. I think that consistency with the existing configuration options outweighs this concern.