### PR TITLE
Refactor and fix state contexts in Rust backend

### DIFF
--- a/framec/src/frame_c/default_config.yaml
+++ b/framec/src/frame_c/default_config.yaml
@@ -16,9 +16,12 @@ codegen:
       enter_msg: Enter
       exit_msg: Exit
       enter_args_member_name: enter_args
+      enter_args_suffix: EnterArgs
       exit_args_member_name: exit_args
       state_args_var: state_args
+      state_args_suffix: StateArgs
       state_vars_var_name: state_vars
+      state_vars_suffix: StateVars
       state_context_name: StateContext
       state_context_suffix: StateContext
       state_context_var_name: state_context

--- a/framec/src/frame_c/parser.rs
+++ b/framec/src/frame_c/parser.rs
@@ -3444,31 +3444,6 @@ impl<'a> Parser<'a> {
 
     /* --------------------------------------------------------------------- */
 
-    // state_context ->
-
-    fn change_state_context(
-        &mut self,
-        _: Option<ExprListNode>,
-    ) -> Result<Option<StateContextType>, ParseError> {
-        // parse state ref e.g. '$S1'
-        if !self.match_token(&vec![TokenType::StateTok]) {
-            return Err(ParseError::new("Missing $"));
-        }
-
-        if !self.match_token(&vec![TokenType::IdentifierTok]) {
-            return Err(ParseError::new("Missing state identifier."));
-        }
-
-        let state_id = self.previous();
-        let name = state_id.lexeme.clone();
-
-        let state_context_node = StateContextNode::new(StateRefNode::new(name), None, None);
-
-        Ok(Some(StateContextType::StateRef { state_context_node }))
-    }
-
-    /* --------------------------------------------------------------------- */
-
     // transition : exitArgs '->' enterArgs transitionLabel stateRef stateArgs
 
     fn transition(
@@ -3536,7 +3511,7 @@ impl<'a> Parser<'a> {
         }
 
         let state_context_t;
-        match self.change_state_context(None) {
+        match self.state_context(None) {
             Ok(Some(scn)) => state_context_t = scn,
             Ok(None) => return Err(ParseError::new("TODO")),
             Err(parse_error) => return Err(parse_error),

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -265,7 +265,7 @@ pub struct RustVisitor {
     dent: usize,
     current_state_name_opt: Option<String>,
     current_event_ret_type: String,
-    arcanium: Arcanum,
+    arcanum: Arcanum,
     symbol_config: SymbolConfig,
     comments: Vec<Token>,
     current_comment_idx: usize,
@@ -290,7 +290,7 @@ pub struct RustVisitor {
 
 impl RustVisitor {
     pub fn new(
-        arcanium: Arcanum,
+        arcanum: Arcanum,
         config_yaml: &Yaml,
         generate_exit_args: bool,
         generate_state_context: bool,
@@ -308,7 +308,7 @@ impl RustVisitor {
             dent: 0,
             current_state_name_opt: None,
             current_event_ret_type: String::new(),
-            arcanium,
+            arcanum,
             symbol_config: SymbolConfig::new(),
             comments,
             current_comment_idx: 0,
@@ -361,7 +361,7 @@ impl RustVisitor {
             // "<<" => self.config.stop_system_msg.clone(),
             ">" => self.config.enter_msg.clone(),
             "<" => self.config.exit_msg.clone(),
-            _ => self.arcanium.get_interface_or_msg_from_msg(msg).unwrap(),
+            _ => self.arcanum.get_interface_or_msg_from_msg(msg).unwrap(),
         };
         self.format_type_name(&unformatted)
     }
@@ -397,7 +397,7 @@ impl RustVisitor {
                 param_name
             ),
             None => {
-                let message_opt = self.arcanium.get_interface_or_msg_from_msg(&event_name);
+                let message_opt = self.arcanum.get_interface_or_msg_from_msg(&event_name);
                 match &message_opt {
                     Some(canonical_message_name) => {
                         format!("{}_{}", canonical_message_name, param_name)
@@ -529,7 +529,7 @@ impl RustVisitor {
                     ));
                 } else {
                     let msg = match &self
-                        .arcanium
+                        .arcanum
                         .get_interface_or_msg_from_msg(&self.current_message)
                     {
                         Some(canonical_message_name) => format!("{}", canonical_message_name),
@@ -1237,7 +1237,7 @@ impl RustVisitor {
                 self.generate_change_state();
                 self.newline();
             }
-            if self.arcanium.is_serializable() {
+            if self.arcanum.is_serializable() {
                 for line in self.serialize.iter() {
                     self.code.push_str(&*format!("{}", line));
                     self.code.push_str(&*format!("\n{}", self.dent()));
@@ -1604,7 +1604,7 @@ impl RustVisitor {
         }
         msg.push_str(":");
         msg.push_str(&self.symbol_config.exit_msg_symbol);
-        if let Some(event_sym) = self.arcanium.get_event(&msg, &self.current_state_name_opt) {
+        if let Some(event_sym) = self.arcanum.get_event(&msg, &self.current_state_name_opt) {
             match &event_sym.borrow().params_opt {
                 Some(event_params) => {
                     if exit_args.exprs_t.len() != event_params.len() {
@@ -1676,7 +1676,7 @@ impl RustVisitor {
             "{} {{",
             self.format_enter_args_struct_name(&target_state_name)
         ));
-        if let Some(event_sym) = self.arcanium.get_event(&msg, &self.current_state_name_opt) {
+        if let Some(event_sym) = self.arcanum.get_event(&msg, &self.current_state_name_opt) {
             match &event_sym.borrow().params_opt {
                 Some(event_params) => {
                     has_enter_args = true;
@@ -1729,7 +1729,7 @@ impl RustVisitor {
             "{} {{",
             self.format_state_args_struct_name(&target_state_name)
         ));
-        if let Some(state_sym) = self.arcanium.get_state(&target_state_name) {
+        if let Some(state_sym) = self.arcanum.get_state(&target_state_name) {
             match &state_sym.borrow().params_opt {
                 Some(event_params) => {
                     let mut param_symbols_it = event_params.iter();
@@ -1776,7 +1776,7 @@ impl RustVisitor {
         formatted_state_vars: &mut String,
     ) -> bool {
         let mut has_state_vars = false;
-        if let Some(state_symbol_rcref) = self.arcanium.get_state(&target_state_name) {
+        if let Some(state_symbol_rcref) = self.arcanum.get_state(&target_state_name) {
             let state_symbol = state_symbol_rcref.borrow();
             let state_node = &state_symbol.state_node.as_ref().unwrap().borrow();
             // generate local state variables
@@ -2023,7 +2023,7 @@ impl RustVisitor {
                 msg.push_str(":");
                 msg.push_str(&self.symbol_config.exit_msg_symbol);
 
-                if let Some(event_sym) = self.arcanium.get_event(&msg, &self.current_state_name_opt)
+                if let Some(event_sym) = self.arcanum.get_event(&msg, &self.current_state_name_opt)
                 {
                     match &event_sym.borrow().params_opt {
                         Some(event_params) => {
@@ -2164,10 +2164,10 @@ impl AstVisitor for RustVisitor {
         self.newline();
         self.add_code("None,");
 
-        let vec = self.arcanium.get_event_names();
+        let vec = self.arcanum.get_event_names();
         for unparsed_event_name in vec {
             match self
-                .arcanium
+                .arcanum
                 .get_event(&unparsed_event_name, &self.current_state_name_opt)
             {
                 Some(event_sym) => {
@@ -2515,13 +2515,13 @@ impl AstVisitor for RustVisitor {
         self.newline();
         self.add_code(&format!("{},", self.config.exit_msg));
 
-        let events = self.arcanium.get_event_names();
+        let events = self.arcanum.get_event_names();
         for event in &events {
             //    ret.push(k.clone());
             if self.is_enter_or_exit_message(&event) {
                 continue;
             }
-            let message_opt = self.arcanium.get_interface_or_msg_from_msg(&event);
+            let message_opt = self.arcanum.get_interface_or_msg_from_msg(&event);
             match message_opt {
                 Some(canonical_message_name) => {
                     self.newline();
@@ -2571,7 +2571,7 @@ impl AstVisitor for RustVisitor {
             if self.is_enter_or_exit_message(&event) {
                 continue;
             }
-            let message_opt = self.arcanium.get_interface_or_msg_from_msg(&event);
+            let message_opt = self.arcanum.get_interface_or_msg_from_msg(&event);
             match message_opt {
                 Some(canonical_message_name) => {
                     let formatted_message_name = self.format_type_name(&canonical_message_name);
@@ -2662,10 +2662,10 @@ impl AstVisitor for RustVisitor {
         self.newline();
         self.add_code("}");
 
-        let vec = self.arcanium.get_event_names();
+        let vec = self.arcanum.get_event_names();
         for unparsed_event_name in vec {
             match self
-                .arcanium
+                .arcanum
                 .get_event(&unparsed_event_name, &self.current_state_name_opt)
             {
                 Some(event_sym) => {
@@ -2879,7 +2879,7 @@ impl AstVisitor for RustVisitor {
                 Some(params) => {
                     for param in params {
                         let msg = self
-                            .arcanium
+                            .arcanum
                             .get_msg_from_interface_name(&interface_method_node.name);
 
                         let parameter_enum_name =

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -23,9 +23,12 @@ struct Config {
     enter_msg: String,
     exit_msg: String,
     enter_args_member_name: String,
+    enter_args_suffix: String,
     exit_args_member_name: String,
     state_args_var: String,
+    state_args_suffix: String,
     state_vars_var_name: String,
+    state_vars_suffix: String,
     state_stack_var_name: String,
     state_context_name: String,
     state_context_suffix: String,
@@ -114,6 +117,10 @@ impl Config {
                 .as_str()
                 .unwrap_or_default()
                 .to_string(),
+            enter_args_suffix: (&code_yaml["enter_args_suffix"])
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
             exit_args_member_name: (&code_yaml["exit_args_member_name"])
                 .as_str()
                 .unwrap_or_default()
@@ -199,7 +206,15 @@ impl Config {
                 .as_str()
                 .unwrap_or_default()
                 .to_string(),
+            state_args_suffix: (&code_yaml["state_args_suffix"])
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
             state_vars_var_name: (&code_yaml["state_vars_var_name"])
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+            state_vars_suffix: (&code_yaml["state_vars_suffix"])
                 .as_str()
                 .unwrap_or_default()
                 .to_string(),
@@ -648,15 +663,17 @@ impl RustVisitor {
 
     fn format_enter_args_struct_name(&self, state_name: &str) -> String {
         format!(
-            "{}EnterArgs",
-            self.format_type_name(&state_name.to_string())
+            "{}{}",
+            self.format_type_name(&state_name.to_string()),
+            self.config.enter_args_suffix
         )
     }
 
     fn format_state_args_struct_name(&self, state_name: &str) -> String {
         format!(
-            "{}StateArgs",
-            self.format_type_name(&state_name.to_string())
+            "{}{}",
+            self.format_type_name(&state_name.to_string()),
+            self.config.state_args_suffix
         )
     }
 
@@ -670,8 +687,9 @@ impl RustVisitor {
 
     fn format_state_vars_struct_name(&self, state_name: &str) -> String {
         format!(
-            "{}StateVars",
-            self.format_type_name(&state_name.to_string())
+            "{}{}",
+            self.format_type_name(&state_name.to_string()),
+            self.config.state_vars_suffix
         )
     }
 

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -1839,6 +1839,8 @@ impl RustVisitor {
         self.newline();
         self.add_code("// Start transition ");
         self.newline();
+
+        // get the name of the next state
         let target_state_name = match &transition_statement.target_state_context_t {
             StateContextType::StateRef { state_context_node } => {
                 &state_context_node.state_ref_node.name
@@ -1848,6 +1850,8 @@ impl RustVisitor {
                 ""
             }
         };
+
+        // print the transition label, if provided
         match &transition_statement.label_opt {
             Some(label) => {
                 self.add_code(&format!("// {}", label));
@@ -1861,6 +1865,11 @@ impl RustVisitor {
         if let Some(exit_args) = &transition_statement.exit_args_opt {
             has_exit_args = self.generate_exit_arguments(&target_state_name, &exit_args);
         }
+        let exit_args = if has_exit_args {
+            format!("Some({})", self.config.exit_args_member_name)
+        } else {
+            "None".to_string()
+        };
 
         // generate enter arguments
         let mut has_enter_args = false;
@@ -1943,11 +1952,8 @@ impl RustVisitor {
             ));
             self.newline();
         }
-        let exit_args = if has_exit_args {
-            format!("Some({})", self.config.exit_args_member_name)
-        } else {
-            "None".to_string()
-        };
+
+        // call the transition method
         if self.generate_state_context {
             if self.generate_exit_args {
                 self.add_code(&format!(

--- a/framec_tests/src/state_context.frm
+++ b/framec_tests/src/state_context.frm
@@ -1,7 +1,9 @@
 #StateContextSm
     -interface-
+    LogState
     Inc : i32
     Next [arg:i32]
+    Change [arg:i32]
 
     -machine-
     $Init
@@ -23,6 +25,10 @@
             log("x" x)
             ^
 
+        |LogState|
+            log("x" x)
+            ^
+
         |Inc|
             x = x + 1
             log("x" x)
@@ -31,6 +37,11 @@
         |Next| [arg:i32]
             var tmp = arg * 10  --- FIXME: Swapping this to 10 * arg causes a parse error!
             (10) -> (tmp) $Bar(x)
+            ^
+
+        |Change| [arg:i32]
+            var tmp = x + arg
+            ->> $Bar(tmp)
             ^
 
     $Bar [y:i32]
@@ -44,10 +55,21 @@
             log("z" z)
             ^
 
+        |LogState|
+            log("y" y)
+            log("z" z)
+            ^
+
         |Inc|
             z = z + 1
             log("z" z)
             ^(z)
+
+        |Change| [arg:i32]
+            var tmp = y + z + arg
+            log("tmp" tmp)
+            ->> $Foo
+            ^
 
     -actions-
     log [name:String val:i32]

--- a/framec_tests/src/state_context.frm
+++ b/framec_tests/src/state_context.frm
@@ -1,5 +1,6 @@
 #StateContextSm
     -interface-
+    Start
     LogState
     Inc : i32
     Next [arg:i32]
@@ -7,7 +8,25 @@
 
     -machine-
     $Init
-        |>| -> (3 5) $Foo ^
+        var w:i32 = 0
+
+        |>|
+            w = 3
+            log("w" w)
+            ^
+
+        |Inc|
+            w = w + 1
+            log("w" w)
+            ^(w)
+
+        |LogState|
+            log("w" w)
+            ^
+
+        |Start|
+            -> (3 w) $Foo
+            ^
 
     $Foo
         var x:i32 = 0
@@ -68,7 +87,7 @@
         |Change| [arg:i32]
             var tmp = y + z + arg
             log("tmp" tmp)
-            ->> $Foo
+            ->> $Init
             ^
 
     -actions-

--- a/framec_tests/src/state_context.rs
+++ b/framec_tests/src/state_context.rs
@@ -16,8 +16,22 @@ mod tests {
     use super::*;
 
     #[test]
+    fn initial_state() {
+        let mut sm = StateContextSm::new();
+        let r = sm.inc();
+        assert_eq!(r, 4);
+        sm.log_state();
+        assert_eq!(sm.tape, vec!["w=3", "w=4", "w=4"]);
+    }
+
+    #[test]
     fn transition() {
         let mut sm = StateContextSm::new();
+        sm.inc();
+        sm.inc();
+        sm.tape.clear();
+
+        sm.start();
         assert_eq!(sm.tape, vec!["a=3", "b=5", "x=15"]);
         sm.tape.clear();
 
@@ -41,7 +55,11 @@ mod tests {
     #[test]
     fn change_state() {
         let mut sm = StateContextSm::new();
+        sm.inc();
+        sm.inc();
+        sm.start();
         sm.tape.clear();
+
         sm.inc();
         assert_eq!(sm.tape, vec!["x=16"]);
         sm.tape.clear();
@@ -54,6 +72,7 @@ mod tests {
         sm.inc();
         sm.change(100);
         sm.log_state();
-        assert_eq!(sm.tape, vec!["z=1", "tmp=127", "x=0"]);
+        assert_eq!(sm.state, StateContextSmState::Init);
+        assert_eq!(sm.tape, vec!["z=1", "tmp=127", "w=0"]);
     }
 }

--- a/framec_tests/src/state_context.rs
+++ b/framec_tests/src/state_context.rs
@@ -16,7 +16,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn interaction() {
+    fn transition() {
         let mut sm = StateContextSm::new();
         assert_eq!(sm.tape, vec!["a=3", "b=5", "x=15"]);
         sm.tape.clear();
@@ -36,5 +36,24 @@ mod tests {
         let r = sm.inc();
         assert_eq!(r, 50);
         assert_eq!(sm.tape, vec!["z=48", "z=49", "z=50"]);
+    }
+
+    #[test]
+    fn change_state() {
+        let mut sm = StateContextSm::new();
+        sm.tape.clear();
+        sm.inc();
+        assert_eq!(sm.tape, vec!["x=16"]);
+        sm.tape.clear();
+
+        sm.change(10);
+        sm.log_state();
+        assert_eq!(sm.tape, vec!["y=26", "z=0"]);
+        sm.tape.clear();
+
+        sm.inc();
+        sm.change(100);
+        sm.log_state();
+        assert_eq!(sm.tape, vec!["z=1", "tmp=127", "x=0"]);
     }
 }

--- a/framec_tests/src/transition_params.frm
+++ b/framec_tests/src/transition_params.frm
@@ -1,33 +1,42 @@
 #TransitParams
     -interface-
     Next
+    Change
 
     -machine-
     $Init
         |Next|
             -> ("hi A") $A ^
+        |Change|
+            ->> $A ^
 
     $A
         |>| [msg:String]
             log(msg.clone()) ^
-        
-        |<| 
+
+        |<|
             log("bye A") ^
-        
+
         |Next|
             -> ("hi B" 42) $B ^
+
+        |Change|
+            ->> $B ^
 
     $B
         |>| [msg:String val:i16]
             log(msg.clone())
             log(val.to_string()) ^
-        
+
         |<| [val:bool msg:String]
             log(val.to_string())
             log(msg.clone()) ^
-        
+
         |Next|
             (true "bye B") -> ("hi again A") $A ^
+
+        |Change|
+            ->> $A ^
 
     -actions-
     log [msg:String]

--- a/framec_tests/src/transition_params.frm
+++ b/framec_tests/src/transition_params.frm
@@ -4,28 +4,34 @@
 
     -machine-
     $Init
-        |>|
-            -> ("hi A" 1) $A ^
+        |Next|
+            -> ("hi A") $A ^
 
     $A
-        |>| [msg:String val:i16]
-            entered(msg.clone() val) ^
+        |>| [msg:String]
+            log(msg.clone()) ^
+        
+        |<| 
+            log("bye A") ^
+        
         |Next|
-            -> ("hi B" 2) $B ^
+            -> ("hi B" 42) $B ^
 
     $B
         |>| [msg:String val:i16]
-            entered(msg.clone() val) ^
+            log(msg.clone())
+            log(val.to_string()) ^
+        
         |<| [val:bool msg:String]
-            exited(val msg.clone()) ^
+            log(val.to_string())
+            log(msg.clone()) ^
+        
         |Next|
-            (true "bye B") -> ("hi again A" 3) $A ^
+            (true "bye B") -> ("hi again A") $A ^
 
     -actions-
-    entered [msg:String val:i16]
-    exited [val:bool msg:String]
+    log [msg:String]
 
     -domain-
-    var enter_log:Log = `vec![]`
-    var exit_log:Log = `vec![]`
+    var tape:Log = `vec![]`
 ##

--- a/framec_tests/src/transition_params.rs
+++ b/framec_tests/src/transition_params.rs
@@ -32,4 +32,36 @@ mod tests {
         sm.next();
         assert_eq!(sm.tape, vec!["true", "bye B", "hi again A"]);
     }
+
+    #[test]
+    fn change_state() {
+        let mut sm = TransitParams::new();
+        assert_eq!(sm.state, TransitParamsState::Init);
+        sm.change();
+        assert_eq!(sm.state, TransitParamsState::A);
+        sm.change();
+        assert_eq!(sm.state, TransitParamsState::B);
+        sm.change();
+        assert_eq!(sm.state, TransitParamsState::A);
+        assert!(sm.tape.is_empty());
+    }
+
+    #[test]
+    fn change_and_transition() {
+        let mut sm = TransitParams::new();
+        sm.change();
+        assert_eq!(sm.state, TransitParamsState::A);
+        assert!(sm.tape.is_empty());
+        sm.next();
+        assert_eq!(sm.state, TransitParamsState::B);
+        assert_eq!(sm.tape, vec!["bye A", "hi B", "42"]);
+        sm.tape.clear();
+        sm.change();
+        assert_eq!(sm.state, TransitParamsState::A);
+        assert!(sm.tape.is_empty());
+        sm.change();
+        sm.next();
+        assert_eq!(sm.state, TransitParamsState::A);
+        assert_eq!(sm.tape, vec!["true", "bye B", "hi again A"]);
+    }
 }

--- a/framec_tests/src/transition_params.rs
+++ b/framec_tests/src/transition_params.rs
@@ -5,11 +5,8 @@ type Log = Vec<String>;
 include!(concat!(env!("OUT_DIR"), "/", "transition_params.rs"));
 
 impl TransitParams {
-    pub fn entered(&mut self, msg: String, val: i16) {
-        self.enter_log.push(format!("{} {}", msg, val));
-    }
-    pub fn exited(&mut self, val: bool, msg: String) {
-        self.exit_log.push(format!("{} {}", val, msg));
+    pub fn log(&mut self, msg: String) {
+        self.tape.push(format!("{}", msg));
     }
 }
 
@@ -21,16 +18,18 @@ mod tests {
     fn enter() {
         let mut sm = TransitParams::new();
         sm.next();
-        assert_eq!(sm.enter_log, vec!["hi A 1", "hi B 2"]);
-        assert_eq!(sm.exit_log, Log::new());
+        assert_eq!(sm.tape, vec!["hi A"]);
     }
-
+    
     #[test]
     fn enter_and_exit() {
         let mut sm = TransitParams::new();
         sm.next();
+        sm.tape.clear();
         sm.next();
-        assert_eq!(sm.enter_log, vec!["hi A 1", "hi B 2", "hi again A 3"]);
-        assert_eq!(sm.exit_log, vec!["true bye B"]);
+        assert_eq!(sm.tape, vec!["bye A", "hi B", "42"]);
+        sm.tape.clear();
+        sm.next();
+        assert_eq!(sm.tape, vec!["true", "bye B", "hi again A"]);
     }
 }

--- a/framec_tests/src/transition_params.rs
+++ b/framec_tests/src/transition_params.rs
@@ -20,7 +20,7 @@ mod tests {
         sm.next();
         assert_eq!(sm.tape, vec!["hi A"]);
     }
-    
+
     #[test]
     fn enter_and_exit() {
         let mut sm = TransitParams::new();


### PR DESCRIPTION
This significantly refactors the generation of the state context initialization code in the Rust backend, making state contexts work correctly and consistently for all ways of entering a state (initial state, transitions, and change-states).

Previously, state contexts were only initialized correctly for transitions, which led to limitations in initial states described in #22 and in change-states, described in #27. Both of these issues are fixed.

For initial states, only state variables and exit parameters are allowed (i.e. not state parameters or enter parameters). It could be possible to also allow either state parameters or enter parameters by passing these in to the state machine constructor. However, it's not clear which of these should take precedence. Also, these features are usually only accessible in Frame, so it would be inconsistent to allow access to them from Rust for initial states. Thus, it seems like a reasonable limitation that these features are not available for initial states.

For change-states, enter and exit parameters are not allowed since these events are not triggered by a change-state.

This PR needs approval from @frame-lang since the PR includes a minor change to the parser to enable parsing state parameters on change-states.

Fixes #22
Fixes #27