### PR TITLE
Manually revert termination tracking work.

### DIFF
--- a/framec/src/frame_c/ast.rs
+++ b/framec/src/frame_c/ast.rs
@@ -533,7 +533,7 @@ pub struct EventHandlerNode {
     pub state_name: String,
     pub msg_t: MessageType,
     pub statements: Vec<DeclOrStmtType>,
-    pub terminator_node_opt: Option<TerminatorExpr>,
+    pub terminator_node: TerminatorExpr,
     pub event_symbol_rcref: Rc<RefCell<EventSymbol>>,
     // this is so we can know to declare a StateContext at the
     // top of the event handler.
@@ -547,7 +547,7 @@ impl EventHandlerNode {
         state_name: String,
         msg_t: MessageType,
         statements: Vec<DeclOrStmtType>,
-        terminator_node: Option<TerminatorExpr>,
+        terminator_node: TerminatorExpr,
         event_symbol_rcref: Rc<RefCell<EventSymbol>>,
         event_handler_has_transition: bool,
         line: usize,
@@ -557,7 +557,7 @@ impl EventHandlerNode {
             state_name,
             msg_t,
             statements,
-            terminator_node_opt: terminator_node,
+            terminator_node: terminator_node,
             event_symbol_rcref,
             event_handler_has_transition,
             line,
@@ -845,16 +845,6 @@ pub enum ExprStmtType {
     },
 }
 
-impl TerminationAttrs for ExprStmtType {
-    fn is_terminated(&self) -> bool {
-        false
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        false
-    }
-}
-
 pub enum StatementType {
     ExpressionStmt {
         expr_stmt_t: ExprStmtType,
@@ -875,58 +865,6 @@ pub enum StatementType {
     NoStmt,
 }
 
-impl TerminationAttrs for StatementType {
-    fn is_terminated(&self) -> bool {
-        match &self {
-            StatementType::ExpressionStmt { expr_stmt_t } => {
-                return expr_stmt_t.is_terminated();
-            }
-            StatementType::TransitionStmt {
-                transition_statement,
-            } => {
-                return transition_statement.is_terminated();
-            }
-            StatementType::ChangeStateStmt { change_state_stmt } => {
-                return change_state_stmt.is_terminated();
-            }
-            StatementType::TestStmt { test_stmt_node } => {
-                return test_stmt_node.is_terminated();
-            }
-            StatementType::StateStackStmt { .. } => {
-                return false;
-            }
-            StatementType::NoStmt => {
-                return false;
-            }
-        }
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        match &self {
-            StatementType::ExpressionStmt { expr_stmt_t } => {
-                return expr_stmt_t.must_be_terminated();
-            }
-            StatementType::TransitionStmt {
-                transition_statement,
-            } => {
-                return transition_statement.must_be_terminated();
-            }
-            StatementType::ChangeStateStmt { change_state_stmt } => {
-                return change_state_stmt.must_be_terminated();
-            }
-            StatementType::TestStmt { test_stmt_node } => {
-                return test_stmt_node.must_be_terminated();
-            }
-            StatementType::StateStackStmt { .. } => {
-                return false;
-            }
-            StatementType::NoStmt => {
-                return false;
-            }
-        }
-    }
-}
-
 //-----------------------------------------------------//
 
 pub enum DeclOrStmtType {
@@ -936,30 +874,6 @@ pub enum DeclOrStmtType {
     StmtT {
         stmt_t: StatementType,
     },
-}
-
-impl TerminationAttrs for DeclOrStmtType {
-    fn is_terminated(&self) -> bool {
-        match &self {
-            DeclOrStmtType::StmtT { stmt_t } => {
-                return stmt_t.is_terminated();
-            }
-            DeclOrStmtType::VarDeclT { .. } => {
-                return false;
-            }
-        }
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        match &self {
-            DeclOrStmtType::StmtT { stmt_t } => {
-                return stmt_t.must_be_terminated();
-            }
-            DeclOrStmtType::VarDeclT { .. } => {
-                return false;
-            }
-        }
-    }
 }
 
 //-----------------------------------------------------//
@@ -1092,11 +1006,6 @@ impl NodeElement for VariableStmtNode {
 
 //-----------------------------------------------------//
 
-pub trait TerminationAttrs {
-    fn is_terminated(&self) -> bool;
-    fn must_be_terminated(&self) -> bool;
-}
-
 pub struct TransitionStatementNode {
     pub target_state_context_t: StateContextType,
     pub exit_args_opt: Option<ExprListNode>,
@@ -1119,16 +1028,6 @@ impl TransitionStatementNode {
 impl NodeElement for TransitionStatementNode {
     fn accept(&self, ast_visitor: &mut dyn AstVisitor) {
         ast_visitor.visit_transition_statement_node(self);
-    }
-}
-
-impl TerminationAttrs for TransitionStatementNode {
-    fn is_terminated(&self) -> bool {
-        false
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        true
     }
 }
 
@@ -1156,63 +1055,21 @@ impl NodeElement for ChangeStateStatementNode {
     }
 }
 
-impl TerminationAttrs for ChangeStateStatementNode {
-    fn is_terminated(&self) -> bool {
-        false
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        true
-    }
-}
-
 //-----------------------------------------------------//
 
 pub struct TestStatementNode {
     pub test_t: TestType,
-    pub terminated: bool,
-    pub must_be_terminated: bool,
 }
 
 impl TestStatementNode {
     pub fn new(test_t: TestType) -> TestStatementNode {
-        TestStatementNode {
-            test_t,
-            terminated: false,
-            must_be_terminated: false,
-        }
+        TestStatementNode { test_t }
     }
 }
 
 impl NodeElement for TestStatementNode {
     fn accept(&self, ast_visitor: &mut dyn AstVisitor) {
         ast_visitor.visit_test_statement_node(self);
-    }
-}
-
-impl TerminationAttrs for TestStatementNode {
-    fn is_terminated(&self) -> bool {
-        match &self.test_t {
-            TestType::BoolTest { bool_test_node } => bool_test_node.is_terminated(),
-            TestType::StringMatchTest {
-                string_match_test_node,
-            } => string_match_test_node.is_terminated(),
-            TestType::NumberMatchTest {
-                number_match_test_node,
-            } => number_match_test_node.is_terminated(),
-        }
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        match &self.test_t {
-            TestType::BoolTest { bool_test_node } => bool_test_node.must_be_terminated(),
-            TestType::StringMatchTest {
-                string_match_test_node,
-            } => string_match_test_node.must_be_terminated(),
-            TestType::NumberMatchTest {
-                number_match_test_node,
-            } => number_match_test_node.must_be_terminated(),
-        }
     }
 }
 
@@ -1681,8 +1538,6 @@ pub enum TestType {
 pub struct BoolTestNode {
     pub conditional_branch_nodes: Vec<BoolTestConditionalBranchNode>,
     pub else_branch_node_opt: Option<BoolTestElseBranchNode>,
-    pub terminated: bool,
-    pub must_be_terminated: bool,
 }
 
 impl BoolTestNode {
@@ -1690,29 +1545,9 @@ impl BoolTestNode {
         conditional_branch_nodes: Vec<BoolTestConditionalBranchNode>,
         else_branch_node_opt: Option<BoolTestElseBranchNode>,
     ) -> BoolTestNode {
-        let mut terminated = true;
-        let mut must_be_terminated = false;
-        for branch in &conditional_branch_nodes {
-            // the test node is terminated if all branches are.
-            terminated = terminated && branch.is_terminated();
-            // the test node must be terminated if any branch must.
-            must_be_terminated = must_be_terminated || branch.must_be_terminated();
-        }
-        // the BoolTestNode can only be considered fully terminated
-        // if else branch exists and is also terminated.
-        match else_branch_node_opt {
-            Some(ref else_branch_node) => {
-                terminated = terminated && else_branch_node.is_terminated();
-                must_be_terminated = must_be_terminated || else_branch_node.must_be_terminated();
-            }
-            None => terminated = false,
-        }
-
         BoolTestNode {
             conditional_branch_nodes,
             else_branch_node_opt,
-            terminated,
-            must_be_terminated,
         }
     }
 }
@@ -1723,16 +1558,6 @@ impl NodeElement for BoolTestNode {
     }
 }
 
-impl TerminationAttrs for BoolTestNode {
-    fn is_terminated(&self) -> bool {
-        self.terminated
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        self.must_be_terminated
-    }
-}
-
 //-----------------------------------------------------//
 
 pub struct BoolTestConditionalBranchNode {
@@ -1740,8 +1565,6 @@ pub struct BoolTestConditionalBranchNode {
     pub expr_t: ExprType,
     pub statements: Vec<DeclOrStmtType>,
     pub branch_terminator_expr_opt: Option<TerminatorExpr>,
-    pub terminated: bool,
-    pub must_be_terminated: bool,
 }
 
 impl BoolTestConditionalBranchNode {
@@ -1750,16 +1573,12 @@ impl BoolTestConditionalBranchNode {
         expr_t: ExprType,
         statements: Vec<DeclOrStmtType>,
         branch_terminator_t_opt: Option<TerminatorExpr>,
-        terminated: bool,
-        must_be_terminated: bool,
     ) -> BoolTestConditionalBranchNode {
         BoolTestConditionalBranchNode {
             is_negated,
             expr_t,
             statements,
             branch_terminator_expr_opt: branch_terminator_t_opt,
-            terminated,
-            must_be_terminated,
         }
     }
 }
@@ -1770,37 +1589,21 @@ impl NodeElement for BoolTestConditionalBranchNode {
     }
 }
 
-impl TerminationAttrs for BoolTestConditionalBranchNode {
-    fn is_terminated(&self) -> bool {
-        self.terminated
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        self.must_be_terminated
-    }
-}
-
 //-----------------------------------------------------//
 
 pub struct BoolTestElseBranchNode {
     pub statements: Vec<DeclOrStmtType>,
     pub branch_terminator_expr_opt: Option<TerminatorExpr>,
-    pub terminated: bool,
-    pub must_be_terminated: bool,
 }
 
 impl BoolTestElseBranchNode {
     pub fn new(
         statements: Vec<DeclOrStmtType>,
         branch_terminator_t_opt: Option<TerminatorExpr>,
-        terminated: bool,
-        must_be_terminated: bool,
     ) -> BoolTestElseBranchNode {
         BoolTestElseBranchNode {
             statements,
             branch_terminator_expr_opt: branch_terminator_t_opt,
-            terminated,
-            must_be_terminated,
         }
     }
 }
@@ -1811,24 +1614,12 @@ impl NodeElement for BoolTestElseBranchNode {
     }
 }
 
-impl TerminationAttrs for BoolTestElseBranchNode {
-    fn is_terminated(&self) -> bool {
-        self.terminated
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        self.must_be_terminated
-    }
-}
-
 //-----------------------------------------------------//
 
 pub struct StringMatchTestNode {
     pub expr_t: ExprType,
     pub match_branch_nodes: Vec<StringMatchTestMatchBranchNode>,
     pub else_branch_node_opt: Option<StringMatchTestElseBranchNode>,
-    pub terminated: bool,
-    pub must_be_terminated: bool,
 }
 
 impl StringMatchTestNode {
@@ -1837,30 +1628,10 @@ impl StringMatchTestNode {
         match_branch_nodes: Vec<StringMatchTestMatchBranchNode>,
         else_branch_node_opt: Option<StringMatchTestElseBranchNode>,
     ) -> StringMatchTestNode {
-        let mut terminated = true;
-        let mut must_be_terminated = false;
-        for branch in &match_branch_nodes {
-            // the test node is terminated if all branches are.
-            terminated = terminated && branch.is_terminated();
-            // the test node must be terminated if any branch must.
-            must_be_terminated = must_be_terminated || branch.must_be_terminated();
-        }
-        // the StringMatchTestNode can only be considered fully terminated
-        // if else branch exists and is also terminated.
-        match else_branch_node_opt {
-            Some(ref else_branch_node) => {
-                terminated = terminated && else_branch_node.is_terminated();
-                must_be_terminated = must_be_terminated || else_branch_node.must_be_terminated();
-            }
-            None => terminated = false,
-        }
-
         StringMatchTestNode {
             expr_t,
             match_branch_nodes,
             else_branch_node_opt,
-            terminated,
-            must_be_terminated,
         }
     }
 }
@@ -1871,24 +1642,12 @@ impl NodeElement for StringMatchTestNode {
     }
 }
 
-impl TerminationAttrs for StringMatchTestNode {
-    fn is_terminated(&self) -> bool {
-        self.terminated
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        self.must_be_terminated
-    }
-}
-
 //-----------------------------------------------------//
 
 pub struct StringMatchTestMatchBranchNode {
     pub string_match_pattern_node: StringMatchTestPatternNode,
     pub statements: Vec<DeclOrStmtType>,
     pub branch_terminator_expr_opt: Option<TerminatorExpr>,
-    pub terminated: bool,
-    pub must_be_terminated: bool,
 }
 
 impl StringMatchTestMatchBranchNode {
@@ -1896,15 +1655,11 @@ impl StringMatchTestMatchBranchNode {
         string_match_pattern_node: StringMatchTestPatternNode,
         statements: Vec<DeclOrStmtType>,
         branch_terminator_t_opt: Option<TerminatorExpr>,
-        terminated: bool,
-        must_be_terminated: bool,
     ) -> StringMatchTestMatchBranchNode {
         StringMatchTestMatchBranchNode {
             string_match_pattern_node,
             statements,
             branch_terminator_expr_opt: branch_terminator_t_opt,
-            terminated,
-            must_be_terminated,
         }
     }
 }
@@ -1915,37 +1670,21 @@ impl NodeElement for StringMatchTestMatchBranchNode {
     }
 }
 
-impl TerminationAttrs for StringMatchTestMatchBranchNode {
-    fn is_terminated(&self) -> bool {
-        self.terminated
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        self.must_be_terminated
-    }
-}
-
 //-----------------------------------------------------//
 
 pub struct StringMatchTestElseBranchNode {
     pub statements: Vec<DeclOrStmtType>,
     pub branch_terminator_expr_opt: Option<TerminatorExpr>,
-    pub terminated: bool,
-    pub must_be_terminated: bool,
 }
 
 impl StringMatchTestElseBranchNode {
     pub fn new(
         statements: Vec<DeclOrStmtType>,
         branch_terminator_t_opt: Option<TerminatorExpr>,
-        terminated: bool,
-        must_be_terminated: bool,
     ) -> StringMatchTestElseBranchNode {
         StringMatchTestElseBranchNode {
             statements,
             branch_terminator_expr_opt: branch_terminator_t_opt,
-            terminated,
-            must_be_terminated,
         }
     }
 }
@@ -1956,15 +1695,6 @@ impl NodeElement for StringMatchTestElseBranchNode {
     }
 }
 
-impl TerminationAttrs for StringMatchTestElseBranchNode {
-    fn is_terminated(&self) -> bool {
-        self.terminated
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        self.must_be_terminated
-    }
-}
 //-----------------------------------------------------//
 
 pub struct StringMatchTestPatternNode {
@@ -1991,8 +1721,6 @@ pub struct NumberMatchTestNode {
     pub expr_t: ExprType,
     pub match_branch_nodes: Vec<NumberMatchTestMatchBranchNode>,
     pub else_branch_node_opt: Option<NumberMatchTestElseBranchNode>,
-    terminated: bool,
-    must_be_terminated: bool,
 }
 
 impl NumberMatchTestNode {
@@ -2001,32 +1729,10 @@ impl NumberMatchTestNode {
         match_branch_nodes: Vec<NumberMatchTestMatchBranchNode>,
         else_branch_node_opt: Option<NumberMatchTestElseBranchNode>,
     ) -> NumberMatchTestNode {
-
-        let mut terminated = true;
-        let mut must_be_terminated = false;
-        for branch in &match_branch_nodes {
-            // the test node is terminated if all branches are.
-            terminated = terminated && branch.is_terminated();
-            // the test node must be terminated if any branch must.
-            must_be_terminated = must_be_terminated || branch.must_be_terminated();
-        }
-        // the StringMatchTestNode can only be considered fully terminated
-        // if else branch exists and is also terminated.
-        match else_branch_node_opt {
-            Some(ref else_branch_node) => {
-                terminated = terminated && else_branch_node.is_terminated();
-                must_be_terminated = must_be_terminated || else_branch_node.must_be_terminated();
-            }
-            None => terminated = false,
-        }
-
-
         NumberMatchTestNode {
             expr_t,
             match_branch_nodes,
             else_branch_node_opt,
-            terminated,
-            must_be_terminated,
         }
     }
 }
@@ -2037,24 +1743,12 @@ impl NodeElement for NumberMatchTestNode {
     }
 }
 
-impl TerminationAttrs for NumberMatchTestNode {
-    fn is_terminated(&self) -> bool {
-        self.terminated
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        self.must_be_terminated
-    }
-}
-
 //-----------------------------------------------------//
 
 pub struct NumberMatchTestMatchBranchNode {
     pub number_match_pattern_nodes: Vec<NumberMatchTestPatternNode>,
     pub statements: Vec<DeclOrStmtType>,
     pub branch_terminator_expr_opt: Option<TerminatorExpr>,
-    pub terminated: bool,
-    pub must_be_terminated: bool,
 }
 
 impl NumberMatchTestMatchBranchNode {
@@ -2062,15 +1756,11 @@ impl NumberMatchTestMatchBranchNode {
         number_match_pattern_nodes: Vec<NumberMatchTestPatternNode>,
         statements: Vec<DeclOrStmtType>,
         branch_terminator_t_opt: Option<TerminatorExpr>,
-        terminated: bool,
-        must_be_terminated: bool,
     ) -> NumberMatchTestMatchBranchNode {
         NumberMatchTestMatchBranchNode {
             number_match_pattern_nodes,
             statements,
             branch_terminator_expr_opt: branch_terminator_t_opt,
-            terminated,
-            must_be_terminated,
         }
     }
 }
@@ -2081,37 +1771,21 @@ impl NodeElement for NumberMatchTestMatchBranchNode {
     }
 }
 
-impl TerminationAttrs for NumberMatchTestMatchBranchNode {
-    fn is_terminated(&self) -> bool {
-        self.terminated
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        self.must_be_terminated
-    }
-}
-
 //-----------------------------------------------------//
 
 pub struct NumberMatchTestElseBranchNode {
     pub statements: Vec<DeclOrStmtType>,
     pub branch_terminator_expr_opt: Option<TerminatorExpr>,
-    pub terminated: bool,
-    pub must_be_terminated: bool,
 }
 
 impl NumberMatchTestElseBranchNode {
     pub fn new(
         statements: Vec<DeclOrStmtType>,
         branch_terminator_t_opt: Option<TerminatorExpr>,
-        terminated: bool,
-        must_be_terminated: bool,
     ) -> NumberMatchTestElseBranchNode {
         NumberMatchTestElseBranchNode {
             statements,
             branch_terminator_expr_opt: branch_terminator_t_opt,
-            terminated,
-            must_be_terminated,
         }
     }
 }
@@ -2119,16 +1793,6 @@ impl NumberMatchTestElseBranchNode {
 impl NodeElement for NumberMatchTestElseBranchNode {
     fn accept(&self, ast_visitor: &mut dyn AstVisitor) {
         ast_visitor.visit_number_match_test_else_branch_node(self);
-    }
-}
-
-impl TerminationAttrs for NumberMatchTestElseBranchNode {
-    fn is_terminated(&self) -> bool {
-        self.terminated
-    }
-
-    fn must_be_terminated(&self) -> bool {
-        self.must_be_terminated
     }
 }
 

--- a/framec/src/frame_c/parser.rs
+++ b/framec/src/frame_c/parser.rs
@@ -1905,23 +1905,28 @@ impl<'a> Parser<'a> {
             match self.decl_or_stmt() {
                 Ok(opt_smt) => match opt_smt {
                     Some(statement) => {
-                        // match &statement {
-                        //     DeclOrStmtType::StmtT {stmt_t} => {
-                        //         // Transitions or state changes must be the last statement in
-                        //         // an event handler.
-                        //         match stmt_t {
-                        //             StatementType::TransitionStmt { .. } => {
-                        //                 return statements;
-                        //             },
-                        //             StatementType::ChangeStateStmt { .. } => {
-                        //                 return statements;
-                        //             },
-                        //             _ => {}
-                        //         }
-                        //     },
-                        //     _ => {}
-                        // }
-                        statements.push(statement);
+                        match &statement {
+                            DeclOrStmtType::StmtT { stmt_t } => {
+                                // Transitions or state changes must be the last statement in
+                                // an event handler.
+                                match stmt_t {
+                                    StatementType::TransitionStmt { .. } => {
+                                        statements.push(statement);
+                                        return statements;
+                                    }
+                                    StatementType::ChangeStateStmt { .. } => {
+                                        statements.push(statement);
+                                        return statements;
+                                    }
+                                    _ => {
+                                        statements.push(statement);
+                                    }
+                                }
+                            }
+                            _ => {
+                                statements.push(statement);
+                            }
+                        }
                     }
                     None => {
                         return statements;

--- a/framec/src/frame_c/visitors/cpp_visitor.rs
+++ b/framec/src/frame_c/visitors/cpp_visitor.rs
@@ -1351,10 +1351,8 @@ impl AstVisitor for CppVisitor {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
-        if let Some(terminator_node) = terminator_node_opt {
-            terminator_node.accept(self);
-        }
+        let terminator_node = &evt_handler_node.terminator_node;
+        terminator_node.accept(self);
 
         self.outdent();
 

--- a/framec/src/frame_c/visitors/cs_visitor.rs
+++ b/framec/src/frame_c/visitors/cs_visitor.rs
@@ -1432,10 +1432,8 @@ impl AstVisitor for CsVisitor {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
-        if let Some(terminator_node) = terminator_node_opt {
-            terminator_node.accept(self);
-        }
+        let terminator_node = &evt_handler_node.terminator_node;
+        terminator_node.accept(self);
         self.outdent();
         self.newline();
         self.add_code(&format!("}}"));

--- a/framec/src/frame_c/visitors/cs_visitor_for_bob.rs
+++ b/framec/src/frame_c/visitors/cs_visitor_for_bob.rs
@@ -1479,10 +1479,8 @@ impl AstVisitor for CsVisitorForBob {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
-        if let Some(terminator_node) = terminator_node_opt {
-            terminator_node.accept(self);
-        }
+        let terminator_node = &evt_handler_node.terminator_node;
+        terminator_node.accept(self);
         self.outdent();
 
         self.newline();

--- a/framec/src/frame_c/visitors/gdscript_3_2_visitor.rs
+++ b/framec/src/frame_c/visitors/gdscript_3_2_visitor.rs
@@ -1307,10 +1307,8 @@ impl AstVisitor for GdScript32Visitor {
         self.visit_decl_stmts(&evt_handler_node.statements);
 
         self.event_handler_has_code = evt_handler_node.statements.len() > 0usize;
-        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
-        if let Some(terminator_node) = terminator_node_opt {
-            terminator_node.accept(self);
-        }
+        let terminator_node = &evt_handler_node.terminator_node;
+        terminator_node.accept(self);
         self.outdent();
         self.newline();
 

--- a/framec/src/frame_c/visitors/java_8_visitor.rs
+++ b/framec/src/frame_c/visitors/java_8_visitor.rs
@@ -1431,10 +1431,8 @@ impl AstVisitor for Java8Visitor {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
-        if let Some(terminator_node) = terminator_node_opt {
-            terminator_node.accept(self);
-        }
+        let terminator_node = &evt_handler_node.terminator_node;
+        terminator_node.accept(self);
         self.outdent();
         self.newline();
         self.add_code(&format!("}}"));

--- a/framec/src/frame_c/visitors/javascript_visitor.rs
+++ b/framec/src/frame_c/visitors/javascript_visitor.rs
@@ -1356,10 +1356,8 @@ impl AstVisitor for JavaScriptVisitor {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
-        if let Some(terminator_node) = terminator_node_opt {
-            terminator_node.accept(self);
-        }
+        let terminator_node = &evt_handler_node.terminator_node;
+        terminator_node.accept(self);
         self.outdent();
         self.newline();
         self.add_code(&format!("}}"));

--- a/framec/src/frame_c/visitors/plantuml_visitor.rs
+++ b/framec/src/frame_c/visitors/plantuml_visitor.rs
@@ -1249,10 +1249,8 @@ impl AstVisitor for PlantUmlVisitor {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
-        if let Some(terminator_node) = terminator_node_opt {
-            terminator_node.accept(self);
-        }
+        let terminator_node = &evt_handler_node.terminator_node;
+        terminator_node.accept(self);
 
         // this controls formatting here
         self.first_event_handler = false;

--- a/framec/src/frame_c/visitors/python_visitor.rs
+++ b/framec/src/frame_c/visitors/python_visitor.rs
@@ -1323,10 +1323,8 @@ impl AstVisitor for PythonVisitor {
         self.visit_decl_stmts(&evt_handler_node.statements);
 
         self.event_handler_has_code = evt_handler_node.statements.len() > 0usize;
-        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
-        if let Some(terminator_node) = terminator_node_opt {
-            terminator_node.accept(self);
-        }
+        let terminator_node = &evt_handler_node.terminator_node;
+        terminator_node.accept(self);
         self.outdent();
         self.newline();
 

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -3375,10 +3375,8 @@ impl AstVisitor for RustVisitor {
         // Generate statements
         self.visit_decl_stmts(&evt_handler_node.statements);
 
-        let terminator_node_opt = &evt_handler_node.terminator_node_opt;
-        if let Some(terminator_node) = terminator_node_opt {
-            terminator_node.accept(self);
-        }
+        let terminator_node = &evt_handler_node.terminator_node;
+        terminator_node.accept(self);
         self.outdent();
         self.newline();
         self.add_code(&format!("}}"));

--- a/framec_tests/src/match.frm
+++ b/framec_tests/src/match.frm
@@ -14,7 +14,7 @@
         |Simple| -> $SimpleMatch ^
         |Multi|  -> $MultiMatch ^
         |Nested| -> $NestedMatch ^
-        |Child|  -> $ChildMatch
+        |Child|  -> $ChildMatch ^
 
     $EmptyMatch
         |OnString| [s:String]


### PR DESCRIPTION
This is a manual revert of the work adding termination tracking to the parser and AST, per the discussion on #17.