### PR TITLE
Fix and test state history/stack feature

### DIFF
--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -1235,7 +1235,7 @@ impl RustVisitor {
             }
             if self.generate_state_stack {
                 self.newline();
-                self.generate_state_stack();
+                self.generate_state_stack_methods();
             }
             if self.generate_change_state {
                 self.newline();
@@ -1429,98 +1429,63 @@ impl RustVisitor {
     }
 
     /// Generate state stack methods.
-    fn generate_state_stack(&mut self) {
+    fn generate_state_stack_methods(&mut self) {
+        self.newline();
+        self.add_code(&format!(
+            "fn {}(&mut self) {{",
+            self.config.state_stack_push_method_name
+        ));
+        self.indent();
+        self.newline();
         if self.generate_state_context {
-            self.newline();
             self.add_code(&format!(
-                "fn {}(&mut self, {}: Rc<{}>) {{",
-                self.config.state_stack_push_method_name,
-                self.config.state_context_var_name,
+                "self.{}.push((self.{}, Rc::clone(&self.{})));",
+                self.config.state_stack_var_name,
+                self.config.state_var_name,
+                self.config.state_context_var_name
+            ));
+        } else {
+            self.add_code(&format!(
+                "self.{}.push(self.{});",
+                self.config.state_stack_var_name, self.config.state_var_name
+            ));
+        }
+        self.outdent();
+        self.newline();
+        self.add_code(&format!("}}"));
+        self.newline();
+        self.newline();
+        if self.generate_state_context {
+            self.add_code(&format!(
+                "fn {}(&mut self) -> ({}, Rc<{}>) {{",
+                self.config.state_stack_pop_method_name,
+                self.state_enum_type_name(),
                 self.config.state_context_name
             ));
-            self.indent();
-            self.newline();
-            self.add_code(&format!(
-                "self.{}.push({});",
-                self.config.state_stack_var_name, self.config.state_context_var_name
-            ));
-            self.outdent();
-            self.newline();
-            self.add_code(&format!("}}"));
-            self.newline();
-            self.newline();
-            self.add_code(&format!(
-                "fn {}(&mut self) -> Rc<{}> {{",
-                self.config.state_stack_pop_method_name, self.config.state_context_name
-            ));
-            self.indent();
-            self.newline();
-            self.add_code(&format!(
-                "let state_context_opt = self.{}.pop();",
-                self.config.state_stack_var_name
-            ));
-            self.newline();
-            self.add_code(&format!(" match state_context_opt {{"));
-            self.indent();
-            self.newline();
-            self.add_code(&format!(
-                "Some({}) => {},",
-                self.config.state_context_var_name, self.config.state_context_var_name
-            ));
-            self.newline();
-            self.add_code(&format!(
-                "None => panic!(\"Error - attempt to pop history when history stack is empty.\"),"
-            ));
-            self.outdent();
-            self.newline();
-            self.add_code("}");
         } else {
-            self.newline();
-            self.add_code(&format!(
-                "fn {}(&mut self, state: {}) {{",
-                self.config.state_stack_push_method_name,
-                self.state_enum_type_name()
-            ));
-            self.indent();
-            self.newline();
-            self.add_code(&format!(
-                "self.{}.push(Rc::new(RefCell::new(state)));",
-                self.config.state_stack_var_name
-            ));
-            self.outdent();
-            self.newline();
-            self.add_code(&format!("}}"));
-            self.newline();
-            self.newline();
-
             self.add_code(&format!(
                 "fn {}(&mut self) -> {} {{",
                 self.config.state_stack_pop_method_name,
                 self.state_enum_type_name()
             ));
-            self.indent();
-            self.newline();
-            self.add_code(&format!(
-                "let state_opt = self.{}.pop();",
-                self.config.state_stack_var_name
-            ));
-            self.newline();
-            self.add_code(&format!(" match state_opt {{"));
-            self.indent();
-            self.newline();
-            self.add_code(&format!("Some(state) => *state.borrow(),"));
-            self.newline();
-            self.add_code(&format!(
-                "None => panic!(\"Error - attempt to pop history when history stack is empty.\"),"
-            ));
-            self.outdent();
-            self.newline();
-            self.add_code("}");
         }
+        self.indent();
+        self.newline();
+        self.add_code(&format!(
+            "match self.{}.pop() {{",
+            self.config.state_stack_var_name
+        ));
+        self.indent();
+        self.newline();
+        self.add_code("Some(elem) => elem,");
+        self.newline();
+        self.add_code("None => panic!(\"Error: attempted to pop when history stack is empty.\")");
         self.outdent();
         self.newline();
         self.add_code("}");
+        self.outdent();
         self.newline();
+        self.add_code("}");
     }
 
     //* --------------------------------------------------------------------- *//
@@ -2495,28 +2460,31 @@ impl AstVisitor for RustVisitor {
         ));
 
         // generate state context variable
-
         if self.generate_state_context {
             self.newline();
             self.add_code(&format!(
                 "{}: Rc<{}>,",
                 self.config.state_context_var_name, self.config.state_context_name
             ));
-            if self.generate_state_stack {
+        }
+
+        // generate state stack variable
+        if self.generate_state_stack {
+            if self.generate_state_context {
                 self.newline();
                 self.add_code(&format!(
-                    "{}: Vec<Rc<{}>>,",
-                    self.config.state_stack_var_name, self.config.state_context_name
+                    "{}: Vec<({}, Rc<{}>)>,",
+                    self.config.state_stack_var_name,
+                    self.state_enum_type_name(),
+                    self.config.state_context_name
                 ));
-            }
-        } else {
-            if self.generate_state_stack {
+            } else {
                 self.newline();
-                // TODO state refactor
-                // self.add_code(&format!(
-                //     "{}: Vec<Rc<{}>>,",
-                //     self.config.state_stack_var_name, self.config.frame_state_type_name
-                // ));
+                self.add_code(&format!(
+                    "{}: Vec<{}>,",
+                    self.config.state_stack_var_name,
+                    self.state_enum_type_name()
+                ));
             }
         }
 
@@ -4387,18 +4355,10 @@ impl AstVisitor for RustVisitor {
         {
             StateStackOperationType::Push => {
                 self.newline();
-                if self.generate_state_context {
-                    self.add_code(&format!(
-                        "self.{}(self.{}.clone());",
-                        self.config.state_stack_push_method_name,
-                        self.config.state_context_var_name
-                    ));
-                } else {
-                    self.add_code(&format!(
-                        "self.{}(self.{});",
-                        self.config.state_stack_push_method_name, self.config.state_var_name
-                    ));
-                }
+                self.add_code(&format!(
+                    "self.{}();",
+                    self.config.state_stack_push_method_name
+                ));
             }
             StateStackOperationType::Pop => {
                 if self.generate_state_context {

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -1166,7 +1166,7 @@ impl RustVisitor {
         if self.generate_state_context {
             self.newline();
             self.add_code(&format!(
-                "{}: Rc::new(next_state_context),",
+                "{}: next_state_context,",
                 self.config.state_context_var_name
             ));
         }
@@ -1260,7 +1260,7 @@ impl RustVisitor {
     fn generate_change_state(&mut self) {
         if self.generate_state_context {
             self.add_code(&format!(
-                "fn {}(&mut self, {}: {}, {}: {}) {{",
+                "fn {}(&mut self, {}: {}, {}: Rc<{}>) {{",
                 self.config.change_state_method_name,
                 self.new_state_var_name(),
                 self.state_enum_type_name(),
@@ -1300,7 +1300,7 @@ impl RustVisitor {
         if self.generate_state_context {
             self.newline();
             self.add_code(&format!(
-                "self.{} = Rc::new({});",
+                "self.{} = Rc::clone(&{});",
                 self.config.state_context_var_name,
                 self.new_state_context_var_name()
             ));
@@ -1319,7 +1319,7 @@ impl RustVisitor {
         if self.generate_state_context {
             if self.generate_exit_args {
                 self.add_code(&format!(
-                    "fn {}(&mut self, {}: Option<Box<{}>>, {}: {}, {}: {}) {{",
+                    "fn {}(&mut self, {}: Option<Box<{}>>, {}: {}, {}: Rc<{}>) {{",
                     self.config.transition_method_name,
                     self.config.exit_args_member_name,
                     self.config.frame_event_parameters_type_name,
@@ -1330,7 +1330,7 @@ impl RustVisitor {
                 ));
             } else {
                 self.add_code(&format!(
-                    "fn {}(&mut self, {}: {}, {}: {}) {{",
+                    "fn {}(&mut self, {}: {}, {}: Rc<{}>) {{",
                     self.config.transition_method_name,
                     self.new_state_var_name(),
                     self.state_enum_type_name(),
@@ -1405,7 +1405,7 @@ impl RustVisitor {
         if self.generate_state_context {
             self.newline();
             self.add_code(&format!(
-                "self.{} = Rc::new({});",
+                "self.{} = Rc::clone(&{});",
                 self.config.state_context_var_name,
                 self.new_state_context_var_name()
             ));
@@ -1845,7 +1845,7 @@ impl RustVisitor {
         self.add_code("};");
         self.newline();
         self.add_code(&format!(
-            "let next_state_context = {}::{}(RefCell::new(context));",
+            "let next_state_context = Rc::new({}::{}(RefCell::new(context)));",
             self.config.state_context_name,
             self.format_type_name(&target_state_name.to_string())
         ));
@@ -1855,7 +1855,7 @@ impl RustVisitor {
 
     fn generate_state_ref_change_state(&mut self, change_state_stmt: &ChangeStateStatementNode) {
         self.newline();
-        self.add_code("// Start change state ");
+        self.add_code("// Start change state");
 
         // get the name of the next state
         let target_state_name = match &change_state_stmt.state_context_t {
@@ -1937,51 +1937,11 @@ impl RustVisitor {
         }
     }
 
-    fn generate_state_stack_pop_change_state(&mut self, change_state_stmt: &ChangeStateStatementNode) {
-        self.newline();
-        self.add_code("// Start change state ");
-
-        // print the change-state label, if provided
-        match &change_state_stmt.label_opt {
-            Some(label) => {
-                self.newline();
-                self.add_code(&format!("// {}", label));
-            }
-            None => {}
-        }
-
-        // TODO: generate state arguments?
-
-        // pop the state/context and pass to change-state method
-        self.newline();
-        if self.generate_state_context {
-            self.add_code(&format!(
-                "let (next_state, next_state_context) = self.{}();",
-                self.config.state_stack_pop_method_name
-            ));
-            self.newline();
-            self.add_code(&format!(
-                "self.{}(next_state, *next_state_context);",
-                self.config.change_state_method_name
-            ));
-        } else {
-            self.add_code(&format!(
-                "let next_state = self.{}();",
-                self.config.state_stack_pop_method_name
-            ));
-            self.newline();
-            self.add_code(&format!(
-                "self.{}(next_state);",
-                self.config.change_state_method_name
-            ));
-        }
-    }
-
     //* --------------------------------------------------------------------- *//
 
     fn generate_state_ref_transition(&mut self, transition_stmt: &TransitionStatementNode) {
         self.newline();
-        self.add_code("// Start transition ");
+        self.add_code("// Start transition");
 
         // get the name of the next state
         let target_state_name = match &transition_stmt.target_state_context_t {
@@ -2111,130 +2071,106 @@ impl RustVisitor {
 
     //* --------------------------------------------------------------------- *//
 
-    // NOTE!!: it is *currently* disallowed to send state or event arguments to a state stack pop target
-    // So currently this method just sets any exit_args and pops the context from the state stack.
+    // NOTE: Stack pop change-states do not support passing state arguments.
+    // It's unclear whether this feature makes sense or how to support it.
+    // On a pop transition, the state that is being changed to is not known
+    // statically, so the programmer does not know how many arguments to pass.
+    fn generate_state_stack_pop_change_state(
+        &mut self,
+        change_state_stmt: &ChangeStateStatementNode,
+    ) {
+        self.newline();
+        self.add_code("// Start change state");
 
+        // print the change-state label, if provided
+        match &change_state_stmt.label_opt {
+            Some(label) => {
+                self.newline();
+                self.add_code(&format!("// {}", label));
+            }
+            None => {}
+        }
+
+        // pop the state/context and pass to change-state method
+        self.newline();
+        if self.generate_state_context {
+            self.add_code(&format!(
+                "drop({});",
+                self.config.this_state_context_var_name
+            ));
+            self.newline();
+            self.add_code(&format!(
+                "let (next_state, next_state_context) = self.{}();",
+                self.config.state_stack_pop_method_name
+            ));
+            self.newline();
+            self.add_code(&format!(
+                "self.{}(next_state, next_state_context);",
+                self.config.change_state_method_name
+            ));
+        } else {
+            self.add_code(&format!(
+                "let next_state = self.{}();",
+                self.config.state_stack_pop_method_name
+            ));
+            self.newline();
+            self.add_code(&format!(
+                "self.{}(next_state);",
+                self.config.change_state_method_name
+            ));
+        }
+    }
+
+    //* --------------------------------------------------------------------- *//
+
+    // NOTE: Stack pop transitions do not support passing state or event
+    // arguments. It's unclear whether this feature makes sense or how to
+    // support it. On a pop transition, the state that is being changed to is
+    // not known statically, so the programmer does not know how many arguments
+    // to pass. State variables are supported, however.
     fn generate_state_stack_pop_transition(
         &mut self,
         transition_statement: &TransitionStatementNode,
     ) {
         self.newline();
+        self.add_code("// Start transition");
+
+        // print the transition label, if provided
         match &transition_statement.label_opt {
             Some(label) => {
-                self.add_code(&format!("// {}", label));
                 self.newline();
+                self.add_code(&format!("// {}", label));
             }
             None => {}
         }
 
-        // -- Exit Arguments --
-
-        if let Some(exit_args) = &transition_statement.exit_args_opt {
-            if exit_args.exprs_t.len() > 0 {
-                // Note - searching for event keyed with "State:<"
-                // e.g. "S1:<"
-
-                let mut msg: String = String::new();
-                if let Some(state_name) = &self.current_state_name_opt {
-                    msg = state_name.clone();
-                }
-                msg.push_str(":");
-                msg.push_str(&self.symbol_config.exit_msg_symbol);
-
-                if let Some(event_sym) = self.arcanum.get_event(&msg, &self.current_state_name_opt)
-                {
-                    match &event_sym.borrow().params_opt {
-                        Some(event_params) => {
-                            if exit_args.exprs_t.len() != event_params.len() {
-                                self.errors.push(
-                                    "Fatal error: misaligned parameters to arguments.".to_string(),
-                                );
-                            }
-                            let mut param_symbols_it = event_params.iter();
-                            self.add_code(&format!(
-                                "let mut {} = Box::new({}::new());",
-                                self.config.exit_args_member_name,
-                                self.config.frame_event_parameters_type_name
-                            ));
-                            self.newline();
-                            // Loop through the ARGUMENTS...
-                            for expr_t in &exit_args.exprs_t {
-                                // ...and validate w/ the PARAMETERS
-                                match param_symbols_it.next() {
-                                    Some(p) => {
-                                        let mut expr = String::new();
-                                        expr_t.accept_to_string(self, &mut expr);
-                                        let parameter_enum_name =
-                                            self.format_frame_event_parameter_name(&msg, &p.name);
-
-                                        self.add_code(&format!(
-                                            "(*{}).{}({});",
-                                            self.config.exit_args_member_name,
-                                            self.format_setter_name(&parameter_enum_name),
-                                            expr
-                                        ));
-                                        self.newline();
-                                    }
-                                    None => self.errors.push(format!(
-                                        "Invalid number of arguments for \"{}\" event handler.",
-                                        msg
-                                    )),
-                                }
-                            }
-                        }
-                        None => self
-                            .errors
-                            .push(format!("Fatal error: misaligned parameters to arguments.")),
-                    }
-                } else {
-                    self.errors.push(format!("TODO"));
-                }
-            }
-        }
-
+        // pop the state/context and pass to transition method
+        self.newline();
         if self.generate_state_context {
             self.add_code(&format!(
-                "let {} = self.{}();",
-                self.config.state_context_var_name, self.config.state_stack_pop_method_name
+                "drop({});",
+                self.config.this_state_context_var_name
             ));
             self.newline();
             self.add_code(&format!(
-                "let state = {}.borrow().get_state();",
-                self.config.state_context_var_name
+                "let (next_state, next_state_context) = self.{}();",
+                self.config.state_stack_pop_method_name
+            ));
+            self.newline();
+            self.add_code(&format!(
+                "self.{}(next_state, next_state_context);",
+                self.config.transition_method_name
             ));
         } else {
             self.add_code(&format!(
-                "let state = self.{}();",
+                "let next_state = self.{}();",
                 self.config.state_stack_pop_method_name
             ));
-        }
-        self.newline();
-        if self.generate_exit_args {
-            if self.generate_state_context {
-                self.add_code(&format!(
-                    "self.{}(state, {}, self.{});",
-                    self.config.transition_method_name,
-                    self.config.exit_args_member_name,
-                    self.config.state_context_var_name
-                ));
-            } else {
-                self.add_code(&format!(
-                    "self.{}(state, {});",
-                    self.config.transition_method_name, self.config.exit_args_member_name
-                ));
-            }
-        } else {
-            if self.generate_state_context {
-                self.add_code(&format!(
-                    "self.{}(state, {});",
-                    self.config.transition_method_name, self.config.state_context_var_name
-                ));
-            } else {
-                self.add_code(&format!(
-                    "self.{}(state);",
-                    self.config.transition_method_name
-                ));
-            }
+            self.newline();
+            self.add_code(&format!(
+                "self.{}(next_state);",
+                self.config.transition_method_name
+            ));
         }
     }
 }
@@ -3273,7 +3209,7 @@ impl AstVisitor for RustVisitor {
         if self.generate_state_context {
             self.newline();
             self.add_code(&format!(
-                "let {0}_clone = self.{0}.clone();",
+                "let {0}_clone = Rc::clone(&self.{0});",
                 self.config.state_context_var_name
             ));
             self.newline();

--- a/framec_tests/src/lib.rs
+++ b/framec_tests/src/lib.rs
@@ -7,6 +7,7 @@ mod hierarchical_guard;
 mod r#match;
 mod rust_naming;
 mod state_context;
+mod state_context_stack;
 mod state_params;
 mod state_stack;
 mod state_vars;

--- a/framec_tests/src/lib.rs
+++ b/framec_tests/src/lib.rs
@@ -8,6 +8,7 @@ mod r#match;
 mod rust_naming;
 mod state_context;
 mod state_params;
+mod state_stack;
 mod state_vars;
 mod transition;
 mod transition_params;

--- a/framec_tests/src/state_context_stack.frm
+++ b/framec_tests/src/state_context_stack.frm
@@ -1,0 +1,87 @@
+#StateContextStack
+    -interface-
+    to_a
+    to_b
+    to_c
+    inc
+    value:i32
+    push
+    pop
+    pop_change
+
+    -machine-
+    $A
+        var x:i32 = 0
+        |>|
+            log("A:>") ^
+        |<|
+            log("A:<") ^
+        |inc|
+            x = x + 1 ^
+        |value|
+            ^(x)
+        |to_a|
+            -> $A ^
+        |to_b|
+            -> $B ^
+        |to_c|
+            -> $C ^
+        |push|
+            $$[+] ^
+        |pop|
+            -> $$[-] ^
+        |pop_change|
+            ->> $$[-] ^
+
+    $B
+        var y:i32 = 0
+        |>|
+            log("B:>") ^
+        |<|
+            log("B:<") ^
+        |inc|
+            y = y + 5 ^
+        |value|
+            ^(y)
+        |to_a|
+            -> $A ^
+        |to_b|
+            -> $B ^
+        |to_c|
+            -> $C ^
+        |push|
+            $$[+] ^
+        |pop|
+            -> $$[-] ^
+        |pop_change|
+            ->> $$[-] ^
+
+    $C
+        var z:i32 = 0
+        |>|
+            log("C:>") ^
+        |<|
+            log("C:<") ^
+        |inc|
+            z = z + 10 ^
+        |value|
+            ^(z)
+        |to_a|
+            -> $A ^
+        |to_b|
+            -> $B ^
+        |to_c|
+            -> $C ^
+        |push|
+            $$[+] ^
+        |pop|
+            -> $$[-] ^
+        |pop_change|
+            ->> $$[-] ^
+
+    -actions-
+    log [msg:String]
+
+    -domain-
+    var tape:Log = `vec![]`
+##

--- a/framec_tests/src/state_context_stack.rs
+++ b/framec_tests/src/state_context_stack.rs
@@ -1,0 +1,181 @@
+//! Tests the state stack feature when states have associated contexts.
+//!
+//! Most features of state contexts are not supported by state stacks. In
+//! particular, state parameters and enter/exit parameters are not supported.
+//! The reason is that when transitioning to a popped state, the state is not
+//! known statically, so there is no way for the programmer to know what
+//! arguments must be passed.
+//!
+//! However, state variables are supported by the state stack feature. The
+//! interaction of those features is tested here.
+//!
+//! Additionally, the basic functionality of state stacks are tested again
+//! here since pushing and popping with state contexts is a different code
+//! path than pushing and popping without.
+
+type Log = Vec<String>;
+include!(concat!(env!("OUT_DIR"), "/", "state_context_stack.rs"));
+
+impl StateContextStack {
+    pub fn log(&mut self, msg: String) {
+        self.tape.push(msg);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// Test that a pop restores a pushed state.
+    fn push_pop() {
+        let mut sm = StateContextStack::new();
+        assert_eq!(sm.state, StateContextStackState::A);
+        sm.push();
+        sm.to_b();
+        assert_eq!(sm.state, StateContextStackState::B);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::A);
+    }
+
+    #[test]
+    /// Test that multiple states can be pushed and subsequently restored by
+    /// pops, LIFO style.
+    fn multiple_push_pops() {
+        let mut sm = StateContextStack::new();
+        assert_eq!(sm.state, StateContextStackState::A);
+        sm.push();
+        sm.to_c();
+        sm.push();
+        sm.to_a();
+        sm.push();
+        sm.push();
+        sm.to_c(); // no push
+        sm.to_b();
+        sm.push();
+        sm.to_c();
+        sm.push(); // stack top-to-bottom: C, B, A, A, C, A
+        sm.to_a();
+        assert_eq!(sm.state, StateContextStackState::A);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::C);
+        sm.to_a();
+        assert_eq!(sm.state, StateContextStackState::A);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::B);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::A);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::A);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::C);
+        sm.to_b();
+        sm.push();
+        sm.to_c();
+        sm.push(); // stack top-to-bottom: C, B, A
+        sm.to_a();
+        sm.to_b();
+        assert_eq!(sm.state, StateContextStackState::B);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::C);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::B);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::A);
+    }
+
+    #[test]
+    /// Test that pop transitions trigger enter/exit events.
+    fn pop_transition_events() {
+        let mut sm = StateContextStack::new();
+        sm.to_b();
+        sm.push();
+        sm.to_a();
+        sm.push();
+        sm.to_c();
+        sm.push(); // stack top-to-bottom: C, A, B
+        sm.to_a();
+        sm.tape.clear();
+        assert_eq!(sm.state, StateContextStackState::A);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::C);
+        assert_eq!(sm.tape, vec!["A:<", "C:>"]);
+        sm.tape.clear();
+        sm.pop();
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::B);
+        assert_eq!(sm.tape, vec!["C:<", "A:>", "A:<", "B:>"]);
+    }
+
+    #[test]
+    /// Test that pop change-states do not trigger enter/exit events.
+    fn pop_change_state_no_events() {
+        let mut sm = StateContextStack::new();
+        sm.to_b();
+        sm.push();
+        sm.to_a();
+        sm.push();
+        sm.to_c();
+        sm.push(); // stack top-to-bottom: C, A, B
+        sm.to_a();
+        sm.tape.clear();
+        assert_eq!(sm.state, StateContextStackState::A);
+        sm.pop_change();
+        assert_eq!(sm.state, StateContextStackState::C);
+        assert!(sm.tape.is_empty());
+        sm.pop();
+        sm.pop_change();
+        assert_eq!(sm.state, StateContextStackState::B);
+        assert_eq!(sm.tape, vec!["C:<", "A:>"]);
+    }
+
+    #[test]
+    /// Test that state variables are restored after pop.
+    fn pop_restores_state_variables() {
+        let mut sm = StateContextStack::new();
+        sm.inc();
+        sm.inc();
+        sm.push();
+        assert_eq!(sm.state, StateContextStackState::A);
+        assert_eq!(sm.value(), 2);
+        sm.to_b();
+        sm.inc();
+        sm.push();
+        assert_eq!(sm.state, StateContextStackState::B);
+        assert_eq!(sm.value(), 5);
+        sm.to_c();
+        sm.inc();
+        sm.inc();
+        sm.inc();
+        sm.push();
+        assert_eq!(sm.state, StateContextStackState::C);
+        assert_eq!(sm.value(), 30);
+        sm.to_a();
+        sm.inc();
+        assert_eq!(sm.state, StateContextStackState::A);
+        assert_eq!(sm.value(), 1);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::C);
+        assert_eq!(sm.value(), 30);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::B);
+        assert_eq!(sm.value(), 5);
+        sm.to_a();
+        sm.inc();
+        sm.inc();
+        sm.inc();
+        sm.push();
+        assert_eq!(sm.state, StateContextStackState::A);
+        assert_eq!(sm.value(), 3);
+        sm.to_c();
+        sm.inc();
+        assert_eq!(sm.state, StateContextStackState::C);
+        assert_eq!(sm.value(), 10);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::A);
+        assert_eq!(sm.value(), 3);
+        sm.pop();
+        assert_eq!(sm.state, StateContextStackState::A);
+        assert_eq!(sm.value(), 2);
+    }
+}

--- a/framec_tests/src/state_stack.frm
+++ b/framec_tests/src/state_stack.frm
@@ -1,0 +1,63 @@
+#StateStack
+    -interface-
+    to_a
+    to_b
+    to_c
+    push
+    pop
+
+    -machine-
+    $A
+        |>|
+            log("A:>") ^
+        |<|
+            log("A:<") ^
+        |to_a|
+            -> $A ^
+        |to_b|
+            -> $B ^
+        |to_c|
+            -> $C ^
+        |push| 
+            $$[+] ^
+        |pop| 
+            -> $$[-] ^
+    
+    $B
+        |>|
+            log("B:>") ^
+        |<|
+            log("B:<") ^
+        |to_a|
+            -> $A ^
+        |to_b|
+            -> $B ^
+        |to_c|
+            -> $C ^
+        |push| 
+            $$[+] ^
+        |pop| 
+            -> $$[-] ^
+    
+    $C
+        |>|
+            log("C:>") ^
+        |<|
+            log("C:<") ^
+        |to_a|
+            -> $A ^
+        |to_b|
+            -> $B ^
+        |to_c|
+            -> $C ^
+        |push| 
+            $$[+] ^
+        |pop| 
+            -> $$[-] ^
+
+    -actions-
+    log [msg:String]
+
+    -domain-
+    var tape:Log = `vec![]`
+##

--- a/framec_tests/src/state_stack.frm
+++ b/framec_tests/src/state_stack.frm
@@ -19,13 +19,13 @@
             -> $B ^
         |to_c|
             -> $C ^
-        |push| 
+        |push|
             $$[+] ^
-        |pop| 
+        |pop|
             -> $$[-] ^
-        --- |pop_change| 
-        ---     ->> $$[-] ^
-    
+        |pop_change|
+            ->> $$[-] ^
+
     $B
         |>|
             log("B:>") ^
@@ -37,13 +37,13 @@
             -> $B ^
         |to_c|
             -> $C ^
-        |push| 
+        |push|
             $$[+] ^
-        |pop| 
+        |pop|
             -> $$[-] ^
-        --- |pop_change| 
-        ---     ->> $$[-] ^
-    
+        |pop_change|
+            ->> $$[-] ^
+
     $C
         |>|
             log("C:>") ^
@@ -55,12 +55,12 @@
             -> $B ^
         |to_c|
             -> $C ^
-        |push| 
+        |push|
             $$[+] ^
-        |pop| 
+        |pop|
             -> $$[-] ^
-        --- |pop_change| 
-        ---     ->> $$[-] ^
+        |pop_change|
+            ->> $$[-] ^
 
     -actions-
     log [msg:String]

--- a/framec_tests/src/state_stack.frm
+++ b/framec_tests/src/state_stack.frm
@@ -5,6 +5,7 @@
     to_c
     push
     pop
+    pop_change
 
     -machine-
     $A
@@ -22,6 +23,8 @@
             $$[+] ^
         |pop| 
             -> $$[-] ^
+        --- |pop_change| 
+        ---     ->> $$[-] ^
     
     $B
         |>|
@@ -38,6 +41,8 @@
             $$[+] ^
         |pop| 
             -> $$[-] ^
+        --- |pop_change| 
+        ---     ->> $$[-] ^
     
     $C
         |>|
@@ -54,6 +59,8 @@
             $$[+] ^
         |pop| 
             -> $$[-] ^
+        --- |pop_change| 
+        ---     ->> $$[-] ^
 
     -actions-
     log [msg:String]

--- a/framec_tests/src/state_stack.rs
+++ b/framec_tests/src/state_stack.rs
@@ -93,4 +93,27 @@ mod tests {
         assert_eq!(sm.state, StateStackState::B);
         assert_eq!(sm.tape, vec!["C:<", "A:>", "A:<", "B:>"]);
     }
+
+    #[test]
+    #[ignore]
+    /// Test that pop change-states do not trigger enter/exit events.
+    fn pop_change_state_no_events() {
+        let mut sm = StateStack::new();
+        sm.to_b();
+        sm.push();
+        sm.to_a();
+        sm.push();
+        sm.to_c();
+        sm.push(); // stack top-to-bottom: C, A, B
+        sm.to_a();
+        sm.tape.clear();
+        assert_eq!(sm.state, StateStackState::A);
+        sm.pop_change();
+        assert_eq!(sm.state, StateStackState::C);
+        assert!(sm.tape.is_empty());
+        sm.pop();
+        sm.pop_change();
+        assert_eq!(sm.state, StateStackState::B);
+        assert_eq!(sm.tape, vec!["C:<", "A:>"]);
+    }
 }

--- a/framec_tests/src/state_stack.rs
+++ b/framec_tests/src/state_stack.rs
@@ -1,4 +1,5 @@
-//! Tests the basic functionality of the state stack feature.
+//! Tests the basic functionality of the state stack feature. This test case
+//! does not include any features that require a state context.
 
 type Log = Vec<String>;
 include!(concat!(env!("OUT_DIR"), "/", "state_stack.rs"));

--- a/framec_tests/src/state_stack.rs
+++ b/framec_tests/src/state_stack.rs
@@ -1,0 +1,96 @@
+//! Tests the basic functionality of the state stack feature.
+
+type Log = Vec<String>;
+include!(concat!(env!("OUT_DIR"), "/", "state_stack.rs"));
+
+impl StateStack {
+    pub fn log(&mut self, msg: String) {
+        self.tape.push(msg);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// Test that a pop restores a pushed state.
+    fn push_pop() {
+        let mut sm = StateStack::new();
+        assert_eq!(sm.state, StateStackState::A);
+        sm.push();
+        sm.to_b();
+        assert_eq!(sm.state, StateStackState::B);
+        sm.pop();
+        assert_eq!(sm.state, StateStackState::A);
+    }
+
+    #[test]
+    /// Test that multiple states can be pushed and subsequently restored by
+    /// pops, LIFO style.
+    fn multiple_push_pops() {
+        let mut sm = StateStack::new();
+        assert_eq!(sm.state, StateStackState::A);
+        sm.push();
+        sm.to_c();
+        sm.push();
+        sm.to_a();
+        sm.push();
+        sm.push();
+        sm.to_c(); // no push
+        sm.to_b();
+        sm.push();
+        sm.to_c();
+        sm.push(); // stack top-to-bottom: C, B, A, A, C, A
+        sm.to_a();
+        assert_eq!(sm.state, StateStackState::A);
+        sm.pop();
+        assert_eq!(sm.state, StateStackState::C);
+        sm.to_a();
+        assert_eq!(sm.state, StateStackState::A);
+        sm.pop();
+        assert_eq!(sm.state, StateStackState::B);
+        sm.pop();
+        assert_eq!(sm.state, StateStackState::A);
+        sm.pop();
+        assert_eq!(sm.state, StateStackState::A);
+        sm.pop();
+        assert_eq!(sm.state, StateStackState::C);
+        sm.to_b();
+        sm.push();
+        sm.to_c();
+        sm.push(); // stack top-to-bottom: C, B, A
+        sm.to_a();
+        sm.to_b();
+        assert_eq!(sm.state, StateStackState::B);
+        sm.pop();
+        assert_eq!(sm.state, StateStackState::C);
+        sm.pop();
+        assert_eq!(sm.state, StateStackState::B);
+        sm.pop();
+        assert_eq!(sm.state, StateStackState::A);
+    }
+
+    #[test]
+    /// Test that pop transitions trigger enter/exit events.
+    fn pop_transition_events() {
+        let mut sm = StateStack::new();
+        sm.to_b();
+        sm.push();
+        sm.to_a();
+        sm.push();
+        sm.to_c();
+        sm.push(); // stack top-to-bottom: C, A, B
+        sm.to_a();
+        sm.tape.clear();
+        assert_eq!(sm.state, StateStackState::A);
+        sm.pop();
+        assert_eq!(sm.state, StateStackState::C);
+        assert_eq!(sm.tape, vec!["A:<", "C:>"]);
+        sm.tape.clear();
+        sm.pop();
+        sm.pop();
+        assert_eq!(sm.state, StateStackState::B);
+        assert_eq!(sm.tape, vec!["C:<", "A:>", "A:<", "B:>"]);
+    }
+}

--- a/framec_tests/src/state_stack.rs
+++ b/framec_tests/src/state_stack.rs
@@ -95,7 +95,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     /// Test that pop change-states do not trigger enter/exit events.
     fn pop_change_state_no_events() {
         let mut sm = StateStack::new();


### PR DESCRIPTION
This PR fixes the implementation of the state stack / state history feature, and provides unit tests checking it's behavior.

Previously, the state stack feature was implemented only for simple transitions that did not involve any state context. This functionality was untested and was later broken by the state refactoring work.

This commit fixes and tests the previous functionality, and also extends and tests the state stack feature to work with the change-state operation and with state variables.

Note that state stacks still do not support several other features that require state contexts. In particular, state parameters and enter/exit parameters are not supported. The reason is that when transitioning to a popped state, the state is not known statically, so there is no way for the programmer to know what arguments must be passed. Resolving this requires either stricter requirements when state stacks are used (e.g. all states must have the same enter/exit and state parameters), or a more dynamic interface for interacting with these features.