### PR TITLE
Fix + test for handler calls w/o state context.

### DIFF
--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -3786,11 +3786,13 @@ impl AstVisitor for RustVisitor {
             } = &call_chain[0]
             {
                 self.this_branch_transitioned = true;
-                self.add_code(&format!(
-                    "drop({});",
-                    self.config.this_state_context_var_name
-                ));
-                self.newline();
+                if self.generate_state_context {
+                    self.add_code(&format!(
+                        "drop({});",
+                        self.config.this_state_context_var_name
+                    ));
+                    self.newline();
+                }
                 interface_method_call_expr_node.accept(self);
                 self.add_code(";");
                 self.newline();

--- a/framec_tests/src/lib.rs
+++ b/framec_tests/src/lib.rs
@@ -7,6 +7,7 @@ mod hierarchical;
 mod hierarchical_guard;
 mod r#match;
 mod rust_naming;
+mod simple_handler_calls;
 mod state_context;
 mod state_context_stack;
 mod state_params;

--- a/framec_tests/src/simple_handler_calls.frm
+++ b/framec_tests/src/simple_handler_calls.frm
@@ -1,0 +1,27 @@
+#SimpleHandlerCalls
+    -interface-
+    A
+    B
+    C
+    D
+    E
+
+    -machine-
+    $Init
+        |A| -> $A ^
+
+        |B| -> $B ^
+
+        |C| A() ^
+
+        |D|
+            B()
+            -> $A ^
+
+        |E|
+            D()
+            C() ^
+
+    $A
+    $B
+##

--- a/framec_tests/src/simple_handler_calls.rs
+++ b/framec_tests/src/simple_handler_calls.rs
@@ -1,0 +1,30 @@
+//! Test directly invoking event handlers from within other event handlers.
+//! This module tests this feature for simple state machines not requiring a
+//! state context. See `handler_calls.rs` for more interesting cases.
+
+include!(concat!(env!("OUT_DIR"), "/", "simple_handler_calls.rs"));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// Test a basic handler call.
+    fn simple_call() {
+        let mut sm = SimpleHandlerCalls::new();
+        sm.c();
+        assert_eq!(sm.state, SimpleHandlerCallsState::A);
+    }
+
+    #[test]
+    /// Test that a handler call terminates the current handler.
+    fn calls_terminate_handler() {
+        let mut sm = SimpleHandlerCalls::new();
+        sm.d();
+        assert_eq!(sm.state, SimpleHandlerCallsState::B);
+
+        sm = SimpleHandlerCalls::new();
+        sm.e();
+        assert_eq!(sm.state, SimpleHandlerCallsState::B);
+    }
+}


### PR DESCRIPTION
I accidentally broke this in my fix for the trickier case by neglecting to guard the generation of a `drop` statement.