### PR TITLE
Sendable callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ version = "0.1.0"
 
 [[package]]
 name = "framec"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "convert_case",
  "downcast-rs",

--- a/frame_runtime/src/machine.rs
+++ b/frame_runtime/src/machine.rs
@@ -31,6 +31,7 @@ mod tests {
     use crate::environment::EMPTY;
     use std::any::Any;
     use std::cell::RefCell;
+    use std::sync::Mutex;
 
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
     enum TestState {
@@ -117,16 +118,18 @@ mod tests {
     #[test]
     fn transition_callbacks() {
         let tape: Vec<String> = Vec::new();
-        let tape_cell = RefCell::new(tape);
+        let tape_mutex = Mutex::new(tape);
         let mut sm = TestMachine::new();
         sm.callback_manager().add_transition_callback(|i| {
-            tape_cell
-                .borrow_mut()
-                .push(format!("{}->{}", i.old_state.name(), i.new_state.name()));
+            tape_mutex.lock().unwrap().push(format!(
+                "{}->{}",
+                i.old_state.name(),
+                i.new_state.name()
+            ));
         });
         sm.next();
         sm.next();
         sm.next();
-        assert_eq!(*tape_cell.borrow(), vec!["A->B", "B->A", "A->B"]);
+        assert_eq!(*tape_mutex.lock().unwrap(), vec!["A->B", "B->A", "A->B"]);
     }
 }

--- a/framec/Cargo.toml
+++ b/framec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "framec"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Mark Truluck <mark@frame-lang.org>"]
 edition = "2018"
 

--- a/framec_tests/src/state_context_stack.rs
+++ b/framec_tests/src/state_context_stack.rs
@@ -26,6 +26,7 @@ impl<'a> StateContextStack<'a> {
 mod tests {
     use super::*;
     use frame_runtime::transition::*;
+    use std::sync::Mutex;
 
     #[test]
     /// Test that a pop restores a pushed state.
@@ -184,10 +185,10 @@ mod tests {
     /// Test that pop transitions and change-states with state contexts trigger
     /// callbacks.
     fn pop_transition_callbacks() {
-        let out: RefCell<String> = RefCell::new(String::new());
+        let out = Mutex::new(String::new());
         let mut sm = StateContextStack::new();
         sm.callback_manager().add_transition_callback(|info| {
-            *out.borrow_mut() = format!(
+            *out.lock().unwrap() = format!(
                 "{}{}{}",
                 info.old_state.name(),
                 match info.kind {
@@ -206,17 +207,17 @@ mod tests {
         sm.inc();
         sm.push(); // stack top-to-bottom: A, B, C
         sm.to_b();
-        assert_eq!(*out.borrow(), "A->B");
+        assert_eq!(*out.lock().unwrap(), "A->B");
         sm.pop();
-        assert_eq!(*out.borrow(), "B->A");
+        assert_eq!(*out.lock().unwrap(), "B->A");
         sm.pop_change();
-        assert_eq!(*out.borrow(), "A->>B");
+        assert_eq!(*out.lock().unwrap(), "A->>B");
         sm.push();
         sm.to_c();
-        assert_eq!(*out.borrow(), "B->C");
+        assert_eq!(*out.lock().unwrap(), "B->C");
         sm.pop_change();
-        assert_eq!(*out.borrow(), "C->>B");
+        assert_eq!(*out.lock().unwrap(), "C->>B");
         sm.pop();
-        assert_eq!(*out.borrow(), "B->C");
+        assert_eq!(*out.lock().unwrap(), "B->C");
     }
 }

--- a/framec_tests/src/state_stack.rs
+++ b/framec_tests/src/state_stack.rs
@@ -14,6 +14,7 @@ impl<'a> StateStack<'a> {
 mod tests {
     use super::*;
     use frame_runtime::transition::*;
+    use std::sync::Mutex;
 
     #[test]
     /// Test that a pop restores a pushed state.
@@ -121,10 +122,10 @@ mod tests {
     #[test]
     /// Test that pop transitions and change-states trigger callbacks.
     fn pop_transition_callbacks() {
-        let out: RefCell<String> = RefCell::new(String::new());
+        let out = Mutex::new(String::new());
         let mut sm = StateStack::new();
         sm.callback_manager().add_transition_callback(|info| {
-            *out.borrow_mut() = format!(
+            *out.lock().unwrap() = format!(
                 "{}{}{}",
                 info.old_state.name(),
                 match info.kind {
@@ -141,17 +142,17 @@ mod tests {
         sm.to_a();
         sm.push(); // stack top-to-bottom: A, B, C
         sm.to_b();
-        assert_eq!(*out.borrow(), "A->B");
+        assert_eq!(*out.lock().unwrap(), "A->B");
         sm.pop();
-        assert_eq!(*out.borrow(), "B->A");
+        assert_eq!(*out.lock().unwrap(), "B->A");
         sm.pop_change();
-        assert_eq!(*out.borrow(), "A->>B");
+        assert_eq!(*out.lock().unwrap(), "A->>B");
         sm.push();
         sm.to_c();
-        assert_eq!(*out.borrow(), "B->C");
+        assert_eq!(*out.lock().unwrap(), "B->C");
         sm.pop_change();
-        assert_eq!(*out.borrow(), "C->>B");
+        assert_eq!(*out.lock().unwrap(), "C->>B");
         sm.pop();
-        assert_eq!(*out.borrow(), "B->C");
+        assert_eq!(*out.lock().unwrap(), "B->C");
     }
 }

--- a/framec_tests/src/transition_params.rs
+++ b/framec_tests/src/transition_params.rs
@@ -14,6 +14,7 @@ impl<'a> TransitParams<'a> {
 mod tests {
     use super::*;
     use frame_runtime::transition::*;
+    use std::sync::Mutex;
 
     #[test]
     fn enter() {
@@ -69,7 +70,7 @@ mod tests {
     #[test]
     /// Test that transition callbacks get event arguments.
     fn callbacks_get_event_args() {
-        let out: RefCell<String> = RefCell::new(String::new());
+        let out = Mutex::new(String::new());
         let mut sm = TransitParams::new();
         sm.callback_manager().add_transition_callback(|info| {
             let mut entry = String::new();
@@ -94,20 +95,20 @@ mod tests {
             info.enter_arguments.lookup("val").map(|any| {
                 entry.push_str(&format!(", val: {}", any.downcast_ref::<i16>().unwrap()));
             });
-            *out.borrow_mut() = entry;
+            *out.lock().unwrap() = entry;
         });
         sm.next();
-        assert_eq!(*out.borrow(), "Init->A, msg: hi A");
+        assert_eq!(*out.lock().unwrap(), "Init->A, msg: hi A");
         sm.next();
-        assert_eq!(*out.borrow(), "A->B, msg: hi B, val: 42");
+        assert_eq!(*out.lock().unwrap(), "A->B, msg: hi B, val: 42");
         sm.next();
         assert_eq!(
-            *out.borrow(),
+            *out.lock().unwrap(),
             "msg: bye B, val: true, B->A, msg: hi again A"
         );
         sm.change();
-        assert_eq!(*out.borrow(), "A->>B");
+        assert_eq!(*out.lock().unwrap(), "A->>B");
         sm.change();
-        assert_eq!(*out.borrow(), "B->>A");
+        assert_eq!(*out.lock().unwrap(), "B->>A");
     }
 }


### PR DESCRIPTION
This makes the runtime interface compatible with running state machines asynchronously.

The key change is adding the Send trait to transition callbacks.

Unfortunately, this means that synchronous applications are a bit more complicated (e.g. you may need to use a `Mutex` in a callback where otherwise a `RefCell` would do), but I think this is preferable to having parallel runtime interfaces for synchronous vs. asynchronous applications.