### PR TITLE
Better config attribute type names

### DIFF
--- a/framec_tests/src/basic.frm
+++ b/framec_tests/src/basic.frm
@@ -1,5 +1,5 @@
-#[feature:codegen.rust.features.generate_action_impl="true"]
-#[feature:codegen.rust.features.runtime_support="true"]
+#[codegen.rust.features.generate_action_impl:bool="true"]
+#[codegen.rust.features.runtime_support:bool="true"]
 #Basic
     -interface-
     A

--- a/framec_tests/src/config.frm
+++ b/framec_tests/src/config.frm
@@ -1,7 +1,7 @@
-#[feature:codegen.rust.features.generate_hook_methods="true"]
-#[code:codegen.rust.code.state_enum_suffix="Nation"]
-#[code:codegen.rust.code.state_var_name="nation"]
-#[code:codegen.rust.code.transition_hook_method_name="oh_its_a_transition"]
+#[codegen.rust.features.generate_hook_methods:bool="true"]
+#[codegen.rust.code.state_enum_suffix:str="Nation"]
+#[codegen.rust.code.state_var_name:str="nation"]
+#[codegen.rust.code.transition_hook_method_name:str="oh_its_a_transition"]
 #Config
     -interface-
     Next

--- a/framec_tests/src/rust_naming_off.frm
+++ b/framec_tests/src/rust_naming_off.frm
@@ -1,5 +1,5 @@
-#[feature:codegen.rust.features.generate_action_impl="true"]
-#[feature:codegen.rust.features.follow_rust_naming="false"]
+#[codegen.rust.features.generate_action_impl:bool="true"]
+#[codegen.rust.features.follow_rust_naming:bool="false"]
 #RustNaming
     -interface-
     snake_event [snake_param:i32]

--- a/framec_tests/src/rust_naming_on.frm
+++ b/framec_tests/src/rust_naming_on.frm
@@ -1,4 +1,4 @@
-#[feature:codegen.rust.features.generate_action_impl="true"]
+#[codegen.rust.features.generate_action_impl:bool="true"]
 #RustNaming
     -interface-
     snake_event [snake_param:i32]

--- a/framec_tests/src/state_context.frm
+++ b/framec_tests/src/state_context.frm
@@ -1,4 +1,4 @@
-#[feature:codegen.rust.features.generate_action_impl="true"]
+#[codegen.rust.features.generate_action_impl:bool="true"]
 #StateContextSm
     -interface-
     Start

--- a/framec_tests/src/state_context_stack.frm
+++ b/framec_tests/src/state_context_stack.frm
@@ -1,4 +1,4 @@
-#[feature:codegen.rust.features.runtime_support="true"]
+#[codegen.rust.features.runtime_support:bool="true"]
 #StateContextStack
     -interface-
     to_a

--- a/framec_tests/src/state_params.frm
+++ b/framec_tests/src/state_params.frm
@@ -1,4 +1,4 @@
-#[feature:codegen.rust.features.runtime_support="true"]
+#[codegen.rust.features.runtime_support:bool="true"]
 #StateParams
     -interface-
     Next

--- a/framec_tests/src/state_stack.frm
+++ b/framec_tests/src/state_stack.frm
@@ -1,4 +1,4 @@
-#[feature:codegen.rust.features.runtime_support="true"]
+#[codegen.rust.features.runtime_support:bool="true"]
 #StateStack
     -interface-
     to_a

--- a/framec_tests/src/state_vars.frm
+++ b/framec_tests/src/state_vars.frm
@@ -1,4 +1,4 @@
-#[feature:codegen.rust.features.runtime_support="true"]
+#[codegen.rust.features.runtime_support:bool="true"]
 #StateVars
     -interface-
     X

--- a/framec_tests/src/transition.frm
+++ b/framec_tests/src/transition.frm
@@ -1,5 +1,5 @@
-#[feature:codegen.rust.features.generate_hook_methods="true"]
-#[feature:codegen.rust.features.runtime_support="true"]
+#[codegen.rust.features.generate_hook_methods:bool="true"]
+#[codegen.rust.features.runtime_support:bool="true"]
 #Transition
     -interface-
     transit

--- a/framec_tests/src/transition_params.frm
+++ b/framec_tests/src/transition_params.frm
@@ -1,4 +1,4 @@
-#[feature:codegen.rust.features.runtime_support="true"]
+#[codegen.rust.features.runtime_support:bool="true"]
 #TransitParams
     -interface-
     Next


### PR DESCRIPTION
This replaces the `feature:` and `code:` prefixes for configuration attributes with the type suffixes `:bool`, `:int`, and `:str`. This is a more general naming scheme, and more consistent with existing Frame syntax.