### PR TITLE
Add some configurable style to the smcat output, simplify visitor

### DIFF
--- a/framec/src/frame_c/ast.rs
+++ b/framec/src/frame_c/ast.rs
@@ -351,6 +351,9 @@ impl MachineBlockNode {
     pub fn new(states: Vec<Rc<RefCell<StateNode>>>) -> MachineBlockNode {
         MachineBlockNode { states }
     }
+    pub fn get_first_state(&self) -> Option<&Rc<RefCell<StateNode>>> {
+        self.states.get(0)
+    }
 }
 
 impl NodeElement for MachineBlockNode {

--- a/framec/src/frame_c/compiler.rs
+++ b/framec/src/frame_c/compiler.rs
@@ -241,13 +241,10 @@ impl Exe {
             visitor.run(&system_node);
             output = visitor.get_code();
         } else if output_format == "plantuml" {
-            // let x = (&semantic_parser).get_arcanum();
-            // semantic_parser = semantic_parser.into_inner();
-            // let y = (&semantic_parser).get_system_hierarchy();
-            let (x, y) = semantic_parser.get_all();
+            let (arcanum, system_hierarchy) = semantic_parser.get_all();
             let mut visitor = PlantUmlVisitor::new(
-                x,
-                y,
+                arcanum,
+                system_hierarchy,
                 generate_state_context,
                 generate_state_stack,
                 generate_change_state,
@@ -273,8 +270,11 @@ impl Exe {
             visitor.run(&system_node);
             output = visitor.get_code();
         } else if output_format == "smcat" {
-            let (x, y) = semantic_parser.get_all();
-            let mut visitor = SmcatVisitor::new(x, y, FRAMEC_VERSION, comments);
+            let mut visitor = SmcatVisitor::new(
+                FRAMEC_VERSION,
+                config,
+                semantic_parser.get_system_hierarchy(),
+            );
             visitor.run(&system_node);
             output = visitor.get_code();
         // } else if output_format == "xstate" {

--- a/framec/src/frame_c/config.rs
+++ b/framec/src/frame_c/config.rs
@@ -188,13 +188,13 @@ pub struct SmcatFeatures {}
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SmcatCode {
     /// Style settings for nodes that do not have any children.
-    simple_state_node_style: String,
+    pub simple_state_node_style: String,
     /// Style settings for nodes that have sub-states as children.
-    parent_state_node_style: String,
+    pub parent_state_node_style: String,
     /// Style settings for "change-state" transitions.
-    change_state_edge_style: String,
+    pub change_state_edge_style: String,
     /// Style settings for standard transitions.
-    transition_edge_style: String,
+    pub transition_edge_style: String,
 }
 
 impl FrameConfig {

--- a/framec/src/frame_c/parser.rs
+++ b/framec/src/frame_c/parser.rs
@@ -154,6 +154,12 @@ impl<'a> Parser<'a> {
 
     /* --------------------------------------------------------------------- */
 
+    pub fn get_system_hierarchy(self) -> SystemHierarchy {
+        self.system_hierarchy_opt.unwrap()
+    }
+
+    /* --------------------------------------------------------------------- */
+
     pub fn get_all(self) -> (Arcanum, SystemHierarchy) {
         (self.arcanum, self.system_hierarchy_opt.unwrap())
     }


### PR DESCRIPTION
This adds some configuration options for the smcat backend, which enables adding style annotations to edges. There are options in place for adding style options to nodes, but these are not used yet.

It also simplifies the implementation of the visitor a bit, removing some superfluous fields and simplifying the control flow logic.

This is a bit of a WIP and not well-tested, but I'm switching gears for a bit, so decided to merge it in. This should be safe since it doesn't affect any other backends.