### PR TITLE
Live rendering of state machines to smcat

### DIFF
--- a/frame_runtime/src/event.rs
+++ b/frame_runtime/src/event.rs
@@ -137,6 +137,7 @@ mod tests {
             fn transitions(&self) -> Vec<TransitionInfo> {
                 vec![
                     TransitionInfo {
+                        id: 0,
                         kind: TransitionKind::Transition,
                         event: MACHINE.events()[0].clone(),
                         label: "",
@@ -144,6 +145,7 @@ mod tests {
                         target: MACHINE.states()[1],
                     },
                     TransitionInfo {
+                        id: 1,
                         kind: TransitionKind::ChangeState,
                         event: MACHINE.events()[0].clone(),
                         label: "",

--- a/frame_runtime/src/info.rs
+++ b/frame_runtime/src/info.rs
@@ -52,6 +52,24 @@ pub trait MachineInfo {
     /// All of the possible transitions between states in this machine.
     fn transitions(&self) -> Vec<TransitionInfo>;
 
+    /// The initial state of the machine, which is is the first state listed in the `machine` block.
+    /// Returns `None` if the machine has no states.
+    fn initial_state(&self) -> Option<&dyn StateInfo> {
+        if self.states().is_empty() {
+            None
+        } else {
+            Some(self.states()[0])
+        }
+    }
+
+    /// The top-level states are those which are not children of another state.
+    fn top_level_states(&self) -> Vec<&dyn StateInfo> {
+        self.states()
+            .into_iter()
+            .filter(|s| s.parent().is_none())
+            .collect()
+    }
+
     /// Get a domain variable declaration by name.
     fn get_variable(&self, name: &str) -> Option<NameInfo> {
         self.variables().into_iter().find(|n| name == n.name)

--- a/frame_runtime/src/info.rs
+++ b/frame_runtime/src/info.rs
@@ -97,7 +97,7 @@ pub trait StateInfo {
     /// The machine this state is contained in.
     fn machine(&self) -> &dyn MachineInfo;
 
-    /// The name of this state.
+    /// The unique name of this state.
     fn name(&self) -> &'static str;
 
     /// The parent of this state, if any.
@@ -192,6 +192,11 @@ pub enum TransitionKind {
 /// `event::TransitionEvent` is produced, which links to the `TransitionInfo` for the statement
 /// that triggered it.
 pub struct TransitionInfo {
+    /// A unique ID for this transition, within the current state machine. This ID corresponds to
+    /// the index of the transition in the vector returned by the `transitions()` method of the
+    /// machine it's contained in.
+    pub id: usize,
+
     /// Whether this is a standard or change-state transition.
     pub kind: TransitionKind,
 

--- a/frame_runtime/src/lib.rs
+++ b/frame_runtime/src/lib.rs
@@ -30,6 +30,7 @@ pub mod env;
 pub mod event;
 pub mod info;
 pub mod live;
+pub mod smcat;
 
 pub use env::*;
 pub use event::*;

--- a/frame_runtime/src/live.rs
+++ b/frame_runtime/src/live.rs
@@ -119,6 +119,7 @@ mod tests {
             fn transitions(&self) -> Vec<TransitionInfo> {
                 vec![
                     TransitionInfo {
+                        id: 0,
                         kind: TransitionKind::Transition,
                         event: MACHINE.events()[0].clone(),
                         label: "",
@@ -126,6 +127,7 @@ mod tests {
                         target: MACHINE.states()[1],
                     },
                     TransitionInfo {
+                        id: 1,
                         kind: TransitionKind::ChangeState,
                         event: MACHINE.events()[0].clone(),
                         label: "",
@@ -286,6 +288,20 @@ mod tests {
         sm.next();
         sm.next();
         assert_eq!(*tape_mutex.lock().unwrap(), vec!["A->B", "B->>A", "A->B"]);
+    }
+
+    #[test]
+    fn transition_info_id() {
+        let tape: Vec<usize> = Vec::new();
+        let tape_mutex = Mutex::new(tape);
+        let mut sm = TestMachine::new();
+        sm.callback_manager().add_transition_callback(|e| {
+            tape_mutex.lock().unwrap().push(e.info.id);
+        });
+        sm.next();
+        sm.next();
+        sm.next();
+        assert_eq!(*tape_mutex.lock().unwrap(), vec![0, 1, 0]);
     }
 
     #[test]

--- a/frame_runtime/src/smcat.rs
+++ b/frame_runtime/src/smcat.rs
@@ -258,7 +258,6 @@ impl Renderer {
     ) {
         let mut state_iter = states.iter().peekable();
         while let Some(state) = state_iter.next() {
-            println!("active: {:?}", active);
             let style = self.style.node(*state, active == Some(state.name()));
             let children = state.children();
             output.push_str(&"  ".repeat(indent));

--- a/frame_runtime/src/smcat.rs
+++ b/frame_runtime/src/smcat.rs
@@ -1,0 +1,298 @@
+//! This module defines an interface for rendering a Frame state machine in smcat. For the style
+//! options, see the [smcat README](https://github.com/sverweij/state-machine-cat/blob/develop/README.md).
+//!
+//! Some of the style options here (e.g. state and transition types) should more properly be
+//! enumerations rather than strings. However, strings are used for simplicity and forward
+//! compatibility with new types that may be added.
+
+use crate::info::*;
+use crate::live::*;
+use std::fmt;
+
+/// Style options for smcat states.
+///
+/// See:
+///  * <https://github.com/sverweij/state-machine-cat/blob/develop/README.md#marking-states-active>
+///  * <https://github.com/sverweij/state-machine-cat/blob/develop/README.md#classes>
+///  * <https://github.com/sverweij/state-machine-cat/blob/develop/README.md#colors-and-line-width>
+///  * <https://github.com/sverweij/state-machine-cat/blob/develop/README.md#state-display-names>
+///  * <https://github.com/sverweij/state-machine-cat/blob/develop/README.md#overriding-the-type-of-a-state>
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NodeStyle {
+    pub active: bool,
+    pub class: Option<String>,
+    pub color: Option<String>,
+    pub label: Option<String>,
+    pub ntype: Option<String>,
+}
+
+/// Style options for smcat transitions.
+///
+/// See:
+///  * <https://github.com/sverweij/state-machine-cat/blob/develop/README.md#classes>
+///  * <https://github.com/sverweij/state-machine-cat/blob/develop/README.md#colors-and-line-width>
+///  * <https://github.com/sverweij/state-machine-cat/blob/develop/README.md#internal-and-external-transitions>
+#[derive(Clone, Debug, PartialEq)]
+pub struct EdgeStyle {
+    pub class: Option<String>,
+    pub color: Option<String>,
+    pub etype: Option<String>,
+    pub width: Option<f32>,
+}
+
+impl Default for NodeStyle {
+    fn default() -> Self {
+        NodeStyle {
+            active: false,
+            class: None,
+            color: None,
+            label: None,
+            ntype: None,
+        }
+    }
+}
+
+impl Default for EdgeStyle {
+    fn default() -> Self {
+        EdgeStyle {
+            class: None,
+            color: None,
+            etype: None,
+            width: None,
+        }
+    }
+}
+
+impl fmt::Display for NodeStyle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut parts = Vec::new();
+        if self.active {
+            parts.push("active".to_string());
+        }
+        if let Some(s) = &self.class {
+            parts.push(format!("class=\"{}\"", s));
+        }
+        if let Some(s) = &self.color {
+            parts.push(format!("color=\"{}\"", s));
+        }
+        if let Some(s) = &self.label {
+            parts.push(format!("label=\"{}\"", s));
+        }
+        if let Some(s) = &self.ntype {
+            parts.push(format!("type={}", s));
+        }
+        if parts.is_empty() {
+            write!(formatter, "")
+        } else {
+            write!(formatter, " [{}]", parts.join(" "))
+        }
+    }
+}
+
+impl fmt::Display for EdgeStyle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut parts = Vec::new();
+        if let Some(s) = &self.class {
+            parts.push(format!("class=\"{}\"", s));
+        }
+        if let Some(s) = &self.color {
+            parts.push(format!("color=\"{}\"", s));
+        }
+        if let Some(s) = &self.etype {
+            parts.push(format!("type={}", s));
+        }
+        if let Some(f) = &self.width {
+            parts.push(format!("width={}", f));
+        }
+        if parts.is_empty() {
+            write!(formatter, "")
+        } else {
+            write!(formatter, " [{}]", parts.join(" "))
+        }
+    }
+}
+
+/// A trait that enables looking up the style of elements in a state machine.
+pub trait Style {
+    /// Get the node style for a state.
+    fn node(&self, info: &dyn StateInfo, active: bool) -> NodeStyle;
+    /// Get the edge style for a transition.
+    fn edge(&self, info: &TransitionInfo, active: bool) -> EdgeStyle;
+}
+
+/// A style implementation that relegates all formatting to CSS via the "class" style options.
+pub struct CssStyle {}
+
+/// A simple style implementation that doesn't require CSS.
+pub struct SimpleStyle {}
+
+impl Style for CssStyle {
+    fn node(&self, info: &dyn StateInfo, active: bool) -> NodeStyle {
+        let mut classes = Vec::new();
+        if active {
+            classes.push("active");
+        }
+        if !info.children().is_empty() {
+            classes.push("parent");
+        }
+        if info.is_stack_pop() {
+            classes.push("stack-pop");
+        }
+        NodeStyle {
+            class: if classes.is_empty() {
+                None
+            } else {
+                Some(classes.join(" "))
+            },
+            ..NodeStyle::default()
+        }
+    }
+    fn edge(&self, info: &TransitionInfo, active: bool) -> EdgeStyle {
+        let mut classes = Vec::new();
+        if active {
+            classes.push("active");
+        }
+        if info.is_change_state() {
+            classes.push("change-state");
+        }
+        EdgeStyle {
+            class: if classes.is_empty() {
+                None
+            } else {
+                Some(classes.join(" "))
+            },
+            ..EdgeStyle::default()
+        }
+    }
+}
+
+impl Style for SimpleStyle {
+    fn node(&self, _info: &dyn StateInfo, active: bool) -> NodeStyle {
+        let mut style = NodeStyle::default();
+        if active {
+            style.active = true;
+            style.color = Some("red".to_string());
+        }
+        style
+    }
+    fn edge(&self, info: &TransitionInfo, active: bool) -> EdgeStyle {
+        let mut style = EdgeStyle::default();
+        if active {
+            style.width = Some(2.0);
+            if info.is_change_state() {
+                style.color = Some("pink".to_string());
+            } else {
+                style.color = Some("red".to_string());
+            }
+        } else if info.is_change_state() {
+            style.color = Some("grey".to_string());
+        }
+        style
+    }
+}
+
+/// Generates smcat diagrams from Frame state machines.
+pub struct Renderer {
+    style: Box<dyn Style>,
+}
+
+impl Renderer {
+    /// Create a new renderer with the given style configuration.
+    pub fn new(style: Box<dyn Style>) -> Self {
+        Renderer { style }
+    }
+
+    /// Generate an smcat diagram illustrating the structure of a state machine, independent of any
+    /// particular execution.
+    pub fn render_static(&self, machine_info: &dyn MachineInfo) -> String {
+        self.render_common(machine_info, None, None)
+    }
+
+    /// Generate an smcat diagram from a snapshot of a running state machine. Depending on the
+    /// style configuration, this can be expected to highlight the running state, most recent
+    /// transition, etc. Eventually, it may show the current values of variables.
+    pub fn render_live<'a>(
+        &self,
+        machine: &'a dyn MachineInstance<'a>,
+        last_transition: Option<usize>,
+    ) -> String {
+        let machine_info = machine.info();
+        let active_state = machine.state().info().name();
+        self.render_common(machine_info, Some(active_state), last_transition)
+    }
+
+    fn render_common(
+        &self,
+        machine_info: &dyn MachineInfo,
+        active_state: Option<&'static str>,
+        last_transition: Option<usize>,
+    ) -> String {
+        let mut output = String::new();
+
+        // render states
+        output.push_str("initial,\n");
+        self.render_states(
+            active_state,
+            0,
+            &machine_info.top_level_states(),
+            &mut output,
+        );
+        output.push_str(";\n\n");
+
+        // render transitions
+        if let Some(init) = machine_info.initial_state() {
+            output.push_str(&format!("initial => {};\n", init.name()));
+        }
+        for transition in machine_info.transitions() {
+            self.render_transition(last_transition, &transition, &mut output);
+        }
+        output
+    }
+
+    fn render_states(
+        &self,
+        active: Option<&'static str>,
+        indent: usize,
+        states: &[&dyn StateInfo],
+        output: &mut String,
+    ) {
+        let mut state_iter = states.iter().peekable();
+        while let Some(state) = state_iter.next() {
+            println!("active: {:?}", active);
+            let style = self.style.node(*state, active == Some(state.name()));
+            let children = state.children();
+            output.push_str(&"  ".repeat(indent));
+            output.push_str(&format!("{}{}", state.name(), style));
+            if !children.is_empty() {
+                output.push_str(" {\n");
+                self.render_states(active, indent + 1, &children, output);
+                output.push_str(&"  ".repeat(indent));
+                output.push('}');
+            }
+            if state_iter.peek().is_some() {
+                output.push_str(",\n");
+            }
+        }
+    }
+
+    fn render_transition(
+        &self,
+        active: Option<usize>,
+        transition: &TransitionInfo,
+        output: &mut String,
+    ) {
+        let style = self.style.edge(transition, active == Some(transition.id));
+        let mut label = transition.label.to_string();
+        if !label.is_empty() {
+            label = format!("/ {}", label);
+        }
+        output.push_str(&format!(
+            "{} -> {}{} : \"  {}{}  \";\n",
+            transition.source.name(),
+            transition.target.name(),
+            style,
+            transition.event.name,
+            label
+        ));
+    }
+}

--- a/frame_runtime/tests/demo.rs
+++ b/frame_runtime/tests/demo.rs
@@ -155,6 +155,7 @@ mod info {
         fn transitions(&self) -> Vec<TransitionInfo> {
             vec![
                 TransitionInfo {
+                    id: 0,
                     kind: TransitionKind::Transition,
                     event: MACHINE.events()[4].clone(),
                     label: "",
@@ -162,6 +163,7 @@ mod info {
                     target: MACHINE.states()[1],
                 },
                 TransitionInfo {
+                    id: 1,
                     kind: TransitionKind::Transition,
                     event: MACHINE.events()[1].clone(),
                     label: "",
@@ -169,6 +171,7 @@ mod info {
                     target: MACHINE.states()[2],
                 },
                 TransitionInfo {
+                    id: 2,
                     kind: TransitionKind::ChangeState,
                     event: MACHINE.events()[1].clone(),
                     label: "",
@@ -997,6 +1000,21 @@ fn transition_callbacks() {
     tape_mutex.lock().unwrap().clear();
     sm.next();
     assert_eq!(*tape_mutex.lock().unwrap(), vec!["kind: Transition", "old: Foo", "new: Bar"]);
+}
+
+#[test]
+fn transition_info_id() {
+    let tape: Vec<usize> = Vec::new();
+    let tape_mutex = Mutex::new(tape);
+    let mut sm = Demo::new();
+    sm.callback_manager().add_transition_callback(|e| {
+        tape_mutex.lock().unwrap().push(e.info.id);
+    });
+    sm.next();
+    sm.inc(5);
+    sm.next();
+    sm.next();
+    assert_eq!(*tape_mutex.lock().unwrap(), vec![1, 2, 1]);
 }
 
 #[test]

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -949,10 +949,13 @@ impl RustVisitor {
         if !self.transitions.is_empty() {
             self.indent();
             let transitions = self.transitions.clone();
+            let mut index = 0;
             for transition in transitions {
                 self.newline();
                 self.add_code("TransitionInfo");
                 self.enter_block();
+                self.add_code(&format!("id: {},", index));
+                self.newline();
                 self.add_code(&format!(
                     "kind: TransitionKind::{},",
                     if transition.is_change_state {
@@ -986,6 +989,7 @@ impl RustVisitor {
                 ));
                 self.exit_block();
                 self.add_code(",");
+                index += 1;
             }
             self.outdent();
             self.newline();

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -949,8 +949,7 @@ impl RustVisitor {
         if !self.transitions.is_empty() {
             self.indent();
             let transitions = self.transitions.clone();
-            let mut index = 0;
-            for transition in transitions {
+            for (index, transition) in transitions.into_iter().enumerate() {
                 self.newline();
                 self.add_code("TransitionInfo");
                 self.enter_block();
@@ -989,7 +988,6 @@ impl RustVisitor {
                 ));
                 self.exit_block();
                 self.add_code(",");
-                index += 1;
             }
             self.outdent();
             self.newline();

--- a/framec_tests/src/basic.rs
+++ b/framec_tests/src/basic.rs
@@ -68,6 +68,15 @@ mod tests {
         assert!(states.iter().any(|s| s.name() == "S1"));
     }
 
+    /// Test that the name of the initial state from the runtime interface is correct.
+    #[test]
+    fn initial_state_name() {
+        let info = Basic::machine_info();
+        let init = info.initial_state();
+        assert!(init.is_some());
+        assert_eq!(init.unwrap().name(), "S0");
+    }
+
     /// Test that the interface names from the runtime interface are correct.
     #[test]
     fn interface_names() {

--- a/framec_tests/src/hierarchical.rs
+++ b/framec_tests/src/hierarchical.rs
@@ -233,6 +233,26 @@ mod tests {
         assert!(states.iter().any(|s| s.name() == "T"));
         assert!(!states.iter().any(|s| s.name() == "A"));
     }
+    
+    /// Test that the initial state from the runtime interface is correct.
+    #[test]
+    fn initial_state() {
+        let info = Hierarchical::machine_info();
+        let init = info.initial_state();
+        assert!(init.is_some());
+        assert_eq!(init.unwrap().name(), "I");
+    }
+
+    /// Test that the top-level states from the runtime interface is correct.
+    #[test]
+    fn top_level_states() {
+        let info = Hierarchical::machine_info();
+        let states = info.top_level_states();
+        assert_eq!(states.len(), 3);
+        assert!(states.iter().any(|s| s.name() == "I"));
+        assert!(states.iter().any(|s| s.name() == "S"));
+        assert!(states.iter().any(|s| s.name() == "T"));
+    }
 
     /// Test that states have the right parents via the runtime interface.
     #[test]

--- a/framec_tests/src/hierarchical.rs
+++ b/framec_tests/src/hierarchical.rs
@@ -233,7 +233,7 @@ mod tests {
         assert!(states.iter().any(|s| s.name() == "T"));
         assert!(!states.iter().any(|s| s.name() == "A"));
     }
-    
+
     /// Test that the initial state from the runtime interface is correct.
     #[test]
     fn initial_state() {

--- a/framec_tests/src/state_context_runtime.rs
+++ b/framec_tests/src/state_context_runtime.rs
@@ -101,7 +101,7 @@ mod tests {
         assert!(states.iter().any(|s| s.name() == "Foo"));
         assert!(states.iter().any(|s| s.name() == "Bar"));
     }
-    
+
     /// Test that the name of the initial state from the runtime interface is correct.
     #[test]
     fn initial_state_name() {

--- a/framec_tests/src/state_context_runtime.rs
+++ b/framec_tests/src/state_context_runtime.rs
@@ -101,6 +101,15 @@ mod tests {
         assert!(states.iter().any(|s| s.name() == "Foo"));
         assert!(states.iter().any(|s| s.name() == "Bar"));
     }
+    
+    /// Test that the name of the initial state from the runtime interface is correct.
+    #[test]
+    fn initial_state_name() {
+        let info = StateContextSm::machine_info();
+        let init = info.initial_state();
+        assert!(init.is_some());
+        assert_eq!(init.unwrap().name(), "Init");
+    }
 
     /// Test that the state variable declarations from the runtime interface are correct.
     #[test]

--- a/framec_tests/src/transition.rs
+++ b/framec_tests/src/transition.rs
@@ -156,8 +156,8 @@ mod tests {
     fn change_state_callback() {
         let transits = Mutex::new(Vec::new());
         let mut sm = Transition::new();
-        sm.callback_manager().add_transition_callback(|i| {
-            log_transits(&transits, i);
+        sm.callback_manager().add_transition_callback(|e| {
+            log_transits(&transits, e);
         });
         sm.change();
         assert_eq!(*transits.lock().unwrap(), vec!["S0->>S1"]);
@@ -170,6 +170,26 @@ mod tests {
         transits.lock().unwrap().clear();
         sm.transit();
         assert_eq!(*transits.lock().unwrap(), vec!["S3->S4", "S4->>S0"]);
+    }
+
+    /// Test that transition IDs are correct.
+    #[test]
+    fn transition_ids() {
+        let ids = Mutex::new(Vec::new());
+        let mut sm = Transition::new();
+        sm.callback_manager().add_transition_callback(|e| {
+            ids.lock().unwrap().push(e.info.id);
+        });
+        sm.transit();
+        sm.transit();
+        sm.transit();
+        assert_eq!(*ids.lock().unwrap(), vec![0, 2, 4, 7, 9]);
+        ids.lock().unwrap().clear();
+        sm.change();
+        sm.change();
+        sm.change();
+        sm.change();
+        assert_eq!(*ids.lock().unwrap(), vec![1, 3, 6, 8]);
     }
 
     /// Test transition hook method.


### PR DESCRIPTION
This adds live, configurable rendering of state machines to smcat via the runtime interface.

This forced the addition of a few new features to the runtime interface:
 * get the initial state from a state machine
 * convenience method to get all top-level states from a machine
 * associate IDs with transitions

I'm going to make a few changes to enable more history tracking via the runtime interface. One benefit of this for visualization is that we will be able to automatically highlight the most recently followed transition.