### PR TITLE
Smcat fixes

### DIFF
--- a/frame_runtime/tests/demo.rs
+++ b/frame_runtime/tests/demo.rs
@@ -522,42 +522,50 @@ mod tests {
     }
 
     use indoc::indoc;
+
     const SMCAT_STATIC: &str = indoc! {r#"
         initial,
         Init,
         Foo,
         Bar;
-        initial => Init;
+
+        initial -> Init;
         Init -> Foo : "  Init:>  ";
         Foo -> Bar : "  next  ";
         Bar -> Foo [color="grey"] : "  next  ";
         "#};
+
     const SMCAT_LIVE_1: &str = indoc! {r#"
         initial,
         Init,
         Foo [active color="red"],
         Bar;
-        initial => Init;
+
+        initial -> Init;
         Init -> Foo [color="red" width=2] : "  Init:>  ";
         Foo -> Bar : "  next  ";
         Bar -> Foo [color="grey"] : "  next  ";
         "#};
+
     const SMCAT_LIVE_2: &str = indoc! {r#"
         initial,
         Init,
         Foo,
         Bar [active color="red"];
-        initial => Init;
+
+        initial -> Init;
         Init -> Foo : "  Init:>  ";
         Foo -> Bar [color="red" width=2] : "  next  ";
         Bar -> Foo [color="grey"] : "  next  ";
         "#};
+
     const SMCAT_LIVE_3: &str = indoc! {r#"
         initial,
         Init,
         Foo [active color="red"],
         Bar;
-        initial => Init;
+
+        initial -> Init;
         Init -> Foo : "  Init:>  ";
         Foo -> Bar : "  next  ";
         Bar -> Foo [color="pink" width=2] : "  next  ";

--- a/framec/src/frame_c/visitors/cpp_visitor.rs
+++ b/framec/src/frame_c/visitors/cpp_visitor.rs
@@ -1365,7 +1365,7 @@ impl AstVisitor for CppVisitor {
 
         method_call.call_expr_list.accept(self);
 
-        self.add_code(&format!(""));
+        self.add_code("");
     }
 
     //* --------------------------------------------------------------------- *//
@@ -1386,7 +1386,7 @@ impl AstVisitor for CppVisitor {
 
         method_call.call_expr_list.accept_to_string(self, output);
 
-        output.push_str(&format!(""));
+        output.push_str("");
     }
 
     //* --------------------------------------------------------------------- *//

--- a/framec/src/frame_c/visitors/cs_visitor.rs
+++ b/framec/src/frame_c/visitors/cs_visitor.rs
@@ -1449,7 +1449,7 @@ impl AstVisitor for CsVisitor {
 
         method_call.call_expr_list.accept(self);
 
-        self.add_code(&format!(""));
+        self.add_code("");
     }
 
     //* --------------------------------------------------------------------- *//
@@ -1470,7 +1470,7 @@ impl AstVisitor for CsVisitor {
 
         method_call.call_expr_list.accept_to_string(self, output);
 
-        output.push_str(&format!(""));
+        output.push_str("");
     }
 
     //* --------------------------------------------------------------------- *//

--- a/framec/src/frame_c/visitors/cs_visitor_for_bob.rs
+++ b/framec/src/frame_c/visitors/cs_visitor_for_bob.rs
@@ -1500,7 +1500,7 @@ impl AstVisitor for CsVisitorForBob {
 
         method_call.call_expr_list.accept(self);
 
-        self.add_code(&format!(""));
+        self.add_code("");
     }
 
     //* --------------------------------------------------------------------- *//
@@ -1521,7 +1521,7 @@ impl AstVisitor for CsVisitorForBob {
 
         method_call.call_expr_list.accept_to_string(self, output);
 
-        output.push_str(&format!(""));
+        output.push_str("");
     }
 
     //* --------------------------------------------------------------------- *//

--- a/framec/src/frame_c/visitors/gdscript_3_2_visitor.rs
+++ b/framec/src/frame_c/visitors/gdscript_3_2_visitor.rs
@@ -1313,7 +1313,7 @@ impl AstVisitor for GdScript32Visitor {
 
         method_call.call_expr_list.accept(self);
 
-        self.add_code(&format!(""));
+        self.add_code("");
     }
 
     //* --------------------------------------------------------------------- *//
@@ -1334,7 +1334,7 @@ impl AstVisitor for GdScript32Visitor {
 
         method_call.call_expr_list.accept_to_string(self, output);
 
-        output.push_str(&format!(""));
+        output.push_str("");
     }
 
     //* --------------------------------------------------------------------- *//

--- a/framec/src/frame_c/visitors/java_8_visitor.rs
+++ b/framec/src/frame_c/visitors/java_8_visitor.rs
@@ -1449,7 +1449,7 @@ impl AstVisitor for Java8Visitor {
 
         method_call.call_expr_list.accept(self);
 
-        self.add_code(&format!(""));
+        self.add_code("");
     }
 
     //* --------------------------------------------------------------------- *//
@@ -1470,7 +1470,7 @@ impl AstVisitor for Java8Visitor {
 
         method_call.call_expr_list.accept_to_string(self, output);
 
-        output.push_str(&format!(""));
+        output.push_str("");
     }
 
     //* --------------------------------------------------------------------- *//

--- a/framec/src/frame_c/visitors/javascript_visitor.rs
+++ b/framec/src/frame_c/visitors/javascript_visitor.rs
@@ -1364,7 +1364,7 @@ impl AstVisitor for JavaScriptVisitor {
 
         method_call.call_expr_list.accept(self);
 
-        self.add_code(&format!(""));
+        self.add_code("");
     }
 
     //* --------------------------------------------------------------------- *//
@@ -1385,7 +1385,7 @@ impl AstVisitor for JavaScriptVisitor {
 
         method_call.call_expr_list.accept_to_string(self, output);
 
-        output.push_str(&format!(""));
+        output.push_str("");
     }
 
     //* --------------------------------------------------------------------- *//
@@ -1429,7 +1429,7 @@ impl AstVisitor for JavaScriptVisitor {
         self.add_code(&action_name);
         action_call.call_expr_list.accept(self);
 
-        self.add_code(&format!(""));
+        self.add_code("");
     }
 
     //* --------------------------------------------------------------------- *//

--- a/framec/src/frame_c/visitors/python_visitor.rs
+++ b/framec/src/frame_c/visitors/python_visitor.rs
@@ -1333,7 +1333,7 @@ impl AstVisitor for PythonVisitor {
 
         method_call.call_expr_list.accept(self);
 
-        self.add_code(&format!(""));
+        self.add_code("");
     }
 
     //* --------------------------------------------------------------------- *//
@@ -1354,7 +1354,7 @@ impl AstVisitor for PythonVisitor {
 
         method_call.call_expr_list.accept_to_string(self, output);
 
-        output.push_str(&format!(""));
+        output.push_str("");
     }
 
     //* --------------------------------------------------------------------- *//

--- a/framec/src/frame_c/visitors/rust_visitor.rs
+++ b/framec/src/frame_c/visitors/rust_visitor.rs
@@ -4432,7 +4432,7 @@ impl AstVisitor for RustVisitor {
 
         method_call.call_expr_list.accept(self);
 
-        self.add_code(&format!(""));
+        self.add_code("");
     }
 
     //* --------------------------------------------------------------------- *//
@@ -4453,7 +4453,7 @@ impl AstVisitor for RustVisitor {
 
         method_call.call_expr_list.accept_to_string(self, output);
 
-        output.push_str(&format!(""));
+        output.push_str("");
     }
 
     //* --------------------------------------------------------------------- *//

--- a/framec/src/frame_c/visitors/xtate_visitor.rs
+++ b/framec/src/frame_c/visitors/xtate_visitor.rs
@@ -1272,7 +1272,7 @@ impl AstVisitor for XStateVisitor {
 
         method_call.call_expr_list.accept(self);
 
-        self.add_code(&format!(""));
+        self.add_code("");
 
 
     }
@@ -1293,7 +1293,7 @@ impl AstVisitor for XStateVisitor {
 
         method_call.call_expr_list.accept_to_string(self, output);
 
-        output.push_str(&format!(""));
+        output.push_str("");
 
     }
 
@@ -1342,7 +1342,7 @@ impl AstVisitor for XStateVisitor {
 
         action_call.call_expr_list.accept(self);
 
-        self.add_code(&format!(""));
+        self.add_code("");
 
     }
 

--- a/framec_tests/src/basic.rs
+++ b/framec_tests/src/basic.rs
@@ -228,4 +228,16 @@ mod tests {
         assert_eq!(entry_log, vec!["S0", "S1", "S0"]);
         assert_eq!(exit_log, vec!["S0", "S1"]);
     }
+
+    /// Test that statically rendered smcat matches smcat rendered via the runtime system.
+    #[test]
+    fn smcat_static_dynamic_same() {
+        let smcat_file = concat!(env!("OUT_DIR"), "/", "basic.smcat");
+        let smcat_static = std::fs::read_to_string(smcat_file).expect("expected smcat file");
+
+        let renderer = smcat::Renderer::new(smcat::CssStyle);
+        let smcat_dynamic = renderer.render_static(Basic::machine_info());
+
+        assert_eq!(smcat_static, smcat_dynamic);
+    }
 }

--- a/framec_tests/src/hierarchical.rs
+++ b/framec_tests/src/hierarchical.rs
@@ -346,4 +346,16 @@ mod tests {
             vec!["S3"]
         );
     }
+
+    /// Test that statically rendered smcat matches smcat rendered via the runtime system.
+    #[test]
+    fn smcat_static_dynamic_same() {
+        let smcat_file = concat!(env!("OUT_DIR"), "/", "hierarchical.smcat");
+        let smcat_static = std::fs::read_to_string(smcat_file).expect("expected smcat file");
+
+        let renderer = smcat::Renderer::new(smcat::CssStyle);
+        let smcat_dynamic = renderer.render_static(Hierarchical::machine_info());
+
+        assert_eq!(smcat_static, smcat_dynamic);
+    }
 }

--- a/framec_tests/src/state_context_runtime.rs
+++ b/framec_tests/src/state_context_runtime.rs
@@ -536,4 +536,16 @@ mod tests {
             assert!(args.lookup("log").is_none());
         }
     }
+
+    /// Test that statically rendered smcat matches smcat rendered via the runtime system.
+    #[test]
+    fn smcat_static_dynamic_same() {
+        let smcat_file = concat!(env!("OUT_DIR"), "/", "state_context_runtime.smcat");
+        let smcat_static = std::fs::read_to_string(smcat_file).expect("expected smcat file");
+
+        let renderer = smcat::Renderer::new(smcat::CssStyle);
+        let smcat_dynamic = renderer.render_static(StateContextSm::machine_info());
+
+        assert_eq!(smcat_static, smcat_dynamic);
+    }
 }


### PR DESCRIPTION
Several fixes to smcat rendering:
- Fixes some errors in both the static smcat visitor and the dynamic smcat rendering via the runtime system.
- Adds missing styling to static smcat rendering.
- Various minor changes to improve the alignment between the static and dynamic smcat renderers.
- Adds some tests checking alignment between the two.

Also fixes some clippy warnings that popped up after updating to the latest stable Rust. 