### PR TITLE
Add details about Frame spec to MachineInfo.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +90,35 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "generic-array",
+]
 
 [[package]]
 name = "downcast-rs"
@@ -131,6 +169,7 @@ dependencies = [
  "figment",
  "serde",
  "serde_yaml",
+ "sha2",
  "structopt",
  "wasm-bindgen",
 ]
@@ -144,6 +183,16 @@ dependencies = [
  "framec",
  "once_cell",
  "walkdir",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -306,6 +355,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +414,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "uncased"

--- a/frame_runtime/src/event.rs
+++ b/frame_runtime/src/event.rs
@@ -214,6 +214,8 @@ mod tests {
         }
 
         static MACHINE: &MachineInfo = &MachineInfo {
+            path_str: None,
+            sha256: None,
             name: "Dummy",
             variables: &[],
             states: &[STATE_A, STATE_B],

--- a/frame_runtime/tests/demo.rs
+++ b/frame_runtime/tests/demo.rs
@@ -69,6 +69,8 @@ mod info {
     }
 
     static MACHINE: &MachineInfo = &MachineInfo {
+        path_str: None,
+        sha256: None,
         name: "Demo",
         variables: &[
             NameInfo {

--- a/frame_runtime/tests/simple.rs
+++ b/frame_runtime/tests/simple.rs
@@ -41,6 +41,8 @@ mod info {
     }
 
     static MACHINE: &MachineInfo = &MachineInfo {
+        path_str: None,
+        sha256: None,
         name: "Simple",
         variables: &[],
         states: &[STATE_A, STATE_B],

--- a/framec/Cargo.toml
+++ b/framec/Cargo.toml
@@ -15,6 +15,7 @@ exitcode = "1.1.2"
 figment = { version = "0.10.6", features = ["yaml"] }
 serde = { version = "1.0", features = ["serde_derive"] }
 serde_yaml = "0.8"
+sha2 = "0.10"
 structopt = "0.3.21"
 wasm-bindgen = "0.2"
 

--- a/framec/src/lib.rs
+++ b/framec/src/lib.rs
@@ -8,7 +8,7 @@ use wasm_bindgen::prelude::*;
 /// a more full-featured entry point.
 pub fn run(frame_code: &str, format: &str) -> String {
     let exe = Exe::new();
-    let result = exe.run(&None, frame_code.to_string(), format.to_string());
+    let result = exe.run(&None, None, frame_code.to_string(), format.to_string());
     match result {
         Ok(code) => code,
         Err(run_error) => {

--- a/framec_tests/src/basic.rs
+++ b/framec_tests/src/basic.rs
@@ -52,6 +52,24 @@ mod tests {
         assert_eq!(sm.state, BasicState::S0);
     }
 
+    /// Test that the file name from the runtime interface is correct.
+    #[test]
+    fn file_name() {
+        let info = Basic::machine_info();
+        assert!(info.file_name().is_some());
+        assert_eq!(info.file_name().unwrap(), "basic.frm");
+    }
+
+    /// Test that the file path from the runtime interface is correct.
+    #[test]
+    fn file_path() {
+        let info = Basic::machine_info();
+        assert!(info.path().is_some());
+        let path = info.path().unwrap();
+        assert!(path.is_relative());
+        assert_eq!(path.to_str().unwrap(), "src/basic.frm");
+    }
+
     /// Test that the machine name from the runtime interface is correct.
     #[test]
     fn machine_name() {


### PR DESCRIPTION
This adds some additional data to the MachineInfo type for the Rust runtime, which captures information about the Frame specification used to generate the state machine. The new data includes the file path of the spec (as passed to Framec) and a sha256 hash of its contents.