### PR TITLE
Prep for v0.8.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "frame_build"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "framec",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "frame_runtime"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "indoc",
  "once_cell",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "framec"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "convert_case",
  "downcast-rs",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "framec_tests"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "frame_build",

--- a/README.md
+++ b/README.md
@@ -23,14 +23,19 @@ This project contains the code for building the Frame Language Transpiler - the 
 
 For details, see the [Release Notes](https://github.com/frame-lang/frame_transpiler/releases).
 
-### Frame v0.7.4
+### Frame v0.8.0
 
-Frame now supports golang!
+A new `frame_build` crate has been added to ease the integration of Frame with
+Rust projects. See the crate-level documentation for more!
 
 ### Frame v0.7.5
 
 The runtime system for the Rust backend now provides the path to and a checksum
 of the `.frm` file that was used to generate the state machine.
+
+### Frame v0.7.4
+
+Frame now supports golang!
 
 
 ## Resources

--- a/frame_build/Cargo.toml
+++ b/frame_build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame_build"
-version = "0.7.5"
+version = "0.8.0"
 authors = ["Eric Walkingshaw <eric.walkingshaw@savant.com>"]
 edition = "2018"
 

--- a/frame_build/src/lib.rs
+++ b/frame_build/src/lib.rs
@@ -29,8 +29,8 @@
 //! frame_build = "0.8"
 //! ```
 //!
-//! You can run the default build process by adding creating the following `build.rs` file and
-//! storing it at the root of your package.
+//! You can run the default build process by adding the following `build.rs` file to the root of
+//! your package.
 //!
 //! ```no_run
 //! use anyhow::Result;

--- a/frame_runtime/Cargo.toml
+++ b/frame_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame_runtime"
-version = "0.7.5"
+version = "0.8.0"
 authors = ["Eric Walkingshaw <eric.walkingshaw@savant.com>"]
 edition = "2018"
 

--- a/framec/Cargo.toml
+++ b/framec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "framec"
-version = "0.7.5"
+version = "0.8.0"
 authors = ["Mark Truluck <mark@frame-lang.org>"]
 edition = "2018"
 

--- a/framec/src/frame_c/compiler.rs
+++ b/framec/src/frame_c/compiler.rs
@@ -27,7 +27,7 @@ pub use crate::frame_c::visitors::TargetLanguage;
 /* --------------------------------------------------------------------- */
 
 static IS_DEBUG: bool = false;
-static FRAMEC_VERSION: &str = "emitted from framec_v0.7.5";
+static FRAMEC_VERSION: &str = "emitted from framec_v0.8.0";
 
 /* --------------------------------------------------------------------- */
 

--- a/framec_tests/Cargo.toml
+++ b/framec_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "framec_tests"
-version = "0.7.5"
+version = "0.8.0"
 authors = ["Eric Walkingshaw <eric.wakingshaw@savant.com>", "Fernando De la Garza <fernando.delagarza@savant.com>"]
 edition = "2018"
 


### PR DESCRIPTION
This just makes all the standard changes to prep for a release. (And fixes one doc typo.)

I'll merge and create the release once I get the 👍 from Mark.